### PR TITLE
Removing unnessasy check

### DIFF
--- a/modules/transport/jms/src/main/java/org/apache/axis2/transport/jms/JMSOutTransportInfo.java
+++ b/modules/transport/jms/src/main/java/org/apache/axis2/transport/jms/JMSOutTransportInfo.java
@@ -91,24 +91,19 @@ public class JMSOutTransportInfo implements OutTransportInfo {
     JMSOutTransportInfo(String targetEPR) {
 
         this.targetEPR = targetEPR;
-        if (!targetEPR.startsWith(JMSConstants.JMS_PREFIX)) {
-            handleException("Invalid prefix for a JMS EPR : " + targetEPR);
-
-        } else {
-            properties = BaseUtils.getEPRProperties(targetEPR);
-            String destinationType = properties.get(JMSConstants.PARAM_DEST_TYPE);
-            if (destinationType != null) {
-                setDestinationType(destinationType);
-            }
-
-            String replyDestinationType = properties.get(JMSConstants.PARAM_REPLY_DEST_TYPE);
-            if (replyDestinationType != null) {
-                setReplyDestinationType(replyDestinationType);
-            }
-
-            replyDestinationName = properties.get(JMSConstants.PARAM_REPLY_DESTINATION);
-            contentTypeProperty = properties.get(JMSConstants.CONTENT_TYPE_PROPERTY_PARAM);
+        properties = BaseUtils.getEPRProperties(targetEPR);
+        String destinationType = properties.get(JMSConstants.PARAM_DEST_TYPE);
+        if (destinationType != null) {
+            setDestinationType(destinationType);
         }
+
+        String replyDestinationType = properties.get(JMSConstants.PARAM_REPLY_DEST_TYPE);
+        if (replyDestinationType != null) {
+            setReplyDestinationType(replyDestinationType);
+        }
+
+        replyDestinationName = properties.get(JMSConstants.PARAM_REPLY_DESTINATION);
+        contentTypeProperty = properties.get(JMSConstants.CONTENT_TYPE_PROPERTY_PARAM);
     }
 
     /**


### PR DESCRIPTION
This check prohibits using a jms sender if it's name != jms

When connecting to multiple JMS brokers, we have to use different names for JMS trp senders
