### PR TITLE
CARBON-15646: Return multiple Set-Cookies

### DIFF
--- a/modules/integration/test/org/apache/axis2/transport/http/CARBON15646CommonsTransportHeadersTest.java
+++ b/modules/integration/test/org/apache/axis2/transport/http/CARBON15646CommonsTransportHeadersTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.axis2.transport.http;
 
 import junit.framework.TestCase;
@@ -12,7 +31,7 @@ public class CARBON15646CommonsTransportHeadersTest extends TestCase {
     CommonsTransportHeaders commonsTransportHeaders;
     String value;
 
-    public void initForRandomNoOfHeaders() {
+    public void initHeaders() {
         int numberOfHeaders = ((Double) (Math.random() * 10000 % 100)).intValue() + 10;
 
         headers = new Header[numberOfHeaders];
@@ -28,10 +47,8 @@ public class CARBON15646CommonsTransportHeadersTest extends TestCase {
     }
 
     @Test
-    public void testForCARBON15646() {
-
-        initForRandomNoOfHeaders();
-
+    public void testCompleteHeaderValueInclusion() {
+        initHeaders();
         // This is to get init() method called.
         commonsTransportHeaders.isEmpty();
         HashMap headerMap = commonsTransportHeaders.headerMap;

--- a/modules/integration/test/org/apache/axis2/transport/http/CARBON15646CommonsTransportHeadersTest.java
+++ b/modules/integration/test/org/apache/axis2/transport/http/CARBON15646CommonsTransportHeadersTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 
 import java.util.HashMap;
 
-public class CARBON15646CommonsTransportHeadersTestCase extends TestCase {
+public class CARBON15646CommonsTransportHeadersTest extends TestCase {
     Header[] headers;
     CommonsTransportHeaders commonsTransportHeaders;
     String value;
@@ -27,7 +27,8 @@ public class CARBON15646CommonsTransportHeadersTestCase extends TestCase {
         commonsTransportHeaders = new CommonsTransportHeaders(headers);
     }
 
-    @Test public void testForCARBON15646() {
+    @Test
+    public void testForCARBON15646() {
 
         initForRandomNoOfHeaders();
 

--- a/modules/integration/test/org/apache/axis2/transport/http/CARBON15646CommonsTransportHeadersTestCase.java
+++ b/modules/integration/test/org/apache/axis2/transport/http/CARBON15646CommonsTransportHeadersTestCase.java
@@ -1,0 +1,40 @@
+package org.apache.axis2.transport.http;
+
+import junit.framework.TestCase;
+import org.apache.commons.httpclient.Header;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+public class CARBON15646CommonsTransportHeadersTestCase extends TestCase {
+    Header[] headers;
+    CommonsTransportHeaders commonsTransportHeaders;
+    String value;
+
+    public void initForRandomNoOfHeaders() {
+        int numberOfHeaders = ((Double) (Math.random() * 10000 % 100)).intValue() + 10;
+
+        headers = new Header[numberOfHeaders];
+        for (int i = 0; i < headers.length; i++) {
+            headers[i] = new Header("name", "value" + i);
+            if (i == 0) {
+                value = "value" + i;
+            } else {
+                value += "; value" + i;
+            }
+        }
+        commonsTransportHeaders = new CommonsTransportHeaders(headers);
+    }
+
+    @Test public void testForCARBON15646() {
+
+        initForRandomNoOfHeaders();
+
+        // This is to get init() method called.
+        commonsTransportHeaders.isEmpty();
+        HashMap headerMap = commonsTransportHeaders.headerMap;
+        Assert.assertTrue(headerMap.containsKey("name"));
+        Assert.assertEquals(headerMap.get("name"), value);
+    }
+}

--- a/modules/transport/http/src/org/apache/axis2/transport/http/CommonsTransportHeaders.java
+++ b/modules/transport/http/src/org/apache/axis2/transport/http/CommonsTransportHeaders.java
@@ -37,9 +37,18 @@ public class CommonsTransportHeaders implements Map {
 
     private void init() {
         headerMap = new HashMap();
-
         for (int i = 0; i < headers.length; i++) {
-            headerMap.put(headers[i].getName(), headers[i].getValue());
+            if (headerMap.containsKey(headers[i].getName())) {
+                String headerValue = (String) headerMap.get(headers[i].getName());
+                if (headerValue != null) {
+                    headerValue = headerValue + "; " + headers[i].getValue();
+                } else {
+                    headerValue = headers[i].getValue();
+                }
+                headerMap.put(headers[i].getName(), headerValue);
+            } else {
+                headerMap.put(headers[i].getName(), headers[i].getValue());
+            }
         }
     }
 


### PR DESCRIPTION
When IS is in a distributed setup fronted by a load balancer, when accessing the dashboard a 401 error occurs due to an AXIS2 bug which causes it to return only one cookie where there are two cookies 
including the one set by the load balancer.
This fix was introduced to solve the above issue.

https://wso2.org/jira/browse/CARBON-15646