### PR TITLE
CARBON-16052 : Incorrect Parsing if Set-Cookie header with 'Expires' …

### DIFF
--- a/modules/transport/http/src/org/apache/axis2/transport/http/AbstractHTTPSender.java
+++ b/modules/transport/http/src/org/apache/axis2/transport/http/AbstractHTTPSender.java
@@ -206,16 +206,7 @@ public abstract class AbstractHTTPSender {
             if (!cookie.equals("")) {
                 cookie = cookie + ";";
             }
-            HeaderElement[] elements = header.getElements();
-            for (HeaderElement element : elements) {
-                cookie = cookie + element.getName() + "=" + element.getValue();
-                NameValuePair[] parameters = element.getParameters();
-                if (parameters != null) {
-                    for (NameValuePair parameter : parameters) {
-                        cookie = cookie + "; " + parameter.getName() + "=" + parameter.getValue();
-                    }
-                }
-            }
+            cookie += header.getValue();
         }
         return cookie;
     }


### PR DESCRIPTION
…attribute contains unquoted comma