### PR TITLE
Fix ESBJAVA-5072

### DIFF
--- a/modules/kernel/src/org/apache/axis2/transport/http/SOAPMessageFormatter.java
+++ b/modules/kernel/src/org/apache/axis2/transport/http/SOAPMessageFormatter.java
@@ -234,7 +234,9 @@ public class SOAPMessageFormatter implements MessageFormatter {
             
             Attachments attachments = msgCtxt.getAttachmentMap();
             for (String contentID : attachments.getAllContentIDs()) {
-                attachmentsWriter.writePart(attachments.getDataHandler(contentID), contentID);
+                if (!contentID.equalsIgnoreCase(attachments.getSOAPPartContentID())) {
+                    attachmentsWriter.writePart(attachments.getDataHandler(contentID), contentID);
+                }
             }
             
             if (MM7CompatMode) {


### PR DESCRIPTION
Fix Soap part comes as attachment when a content aware mediator is in out sequence

`org.apache.axiom.attachments.Attachments#getAllContentIDs` will return the content IDs including the content ID of the SOAP part. So when need to exclude the SOAPPartContentId when creating the attachments.