### PR TITLE
fixing issue https://github.com/wso2/wso2-axis2/issues/128

### DIFF
--- a/modules/transport/http/src/org/apache/axis2/transport/http/util/HTTPProxyConfigurationUtil.java
+++ b/modules/transport/http/src/org/apache/axis2/transport/http/util/HTTPProxyConfigurationUtil.java
@@ -166,7 +166,7 @@ public class HTTPProxyConfigurationUtil {
             proxyPassword = password;
         }
 
-        if (proxyUser != null && proxyPassword != null) {
+        if (proxyUser != null && proxyPassword != null && proxyCredentials == null) {
             proxyCredentials = new UsernamePasswordCredentials(proxyUser, proxyPassword);
         }
 

--- a/modules/transport/http/src/org/apache/axis2/transport/http/util/HTTPProxyConfigurationUtil.java
+++ b/modules/transport/http/src/org/apache/axis2/transport/http/util/HTTPProxyConfigurationUtil.java
@@ -42,6 +42,8 @@ public class HTTPProxyConfigurationUtil {
 
     protected static final String HTTP_PROXY_HOST = "http.proxyHost";
     protected static final String HTTP_PROXY_PORT = "http.proxyPort";
+    protected static final String HTTP_PROXY_USER = "http.proxyUser";
+    protected static final String HTTP_PROXY_PASSWORD = "http.proxyPassword";
     protected static final String HTTP_NON_PROXY_HOSTS = "http.nonProxyHosts";
 
     protected static final String ATTR_PROXY = "Proxy";
@@ -152,6 +154,20 @@ public class HTTPProxyConfigurationUtil {
         String port = System.getProperty(HTTP_PROXY_PORT);
         if(port != null) {
             proxyPort = Integer.parseInt(port);
+        }
+
+        String userName = System.getProperty(HTTP_PROXY_USER);
+        if (userName != null) {
+            proxyUser = userName;
+        }
+
+        String password = System.getProperty(HTTP_PROXY_PASSWORD);
+        if (password != null) {
+            proxyPassword = password;
+        }
+
+        if (proxyUser != null && proxyPassword != null) {
+            proxyCredentials = new UsernamePasswordCredentials(proxyUser, proxyPassword);
         }
 
         if(proxyCredentials != null) {


### PR DESCRIPTION
## Purpose
fixing issue https://github.com/wso2/wso2-axis2/issues/128

## Goals
> Currently, we can't pass proxy server credentials as system properties in axis2 blocking client mode.We can only pass proxyHost and proxyPort parameters.With this fix, we were able to pass proxyUser and proxyPassword as system properties.

