### PR TITLE
Fix for ESBJAVA-5126

### DIFF
--- a/modules/transport/http/src/org/apache/axis2/transport/http/PatchMethod.java
+++ b/modules/transport/http/src/org/apache/axis2/transport/http/PatchMethod.java
@@ -1,0 +1,38 @@
+/*
+*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.axis2.transport.http;
+
+import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
+
+/**
+ * This class is a workaround for missing "PatchMethod" class in commons-httpclient:3.1
+ */
+public class PatchMethod extends EntityEnclosingMethod {
+
+    public PatchMethod() {
+    }
+
+    public PatchMethod(String uri) {
+        super(uri);
+    }
+
+    public String getName() {
+        return "PATCH";
+    }
+}


### PR DESCRIPTION
## Purpose
> Add HTTP PATCH method support to HTTPSender class.

## Goals
> Fixes ESBJAVA-5126

## Approach
> Create new HTTP method PATCH which was not supported in commons-httpclient:3.1

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
