### PR TITLE
Set connection/socket timeout values

### DIFF
--- a/modules/transport/http/src/org/apache/axis2/transport/http/CommonsHTTPTransportSender.java
+++ b/modules/transport/http/src/org/apache/axis2/transport/http/CommonsHTTPTransportSender.java
@@ -153,6 +153,9 @@ public class CommonsHTTPTransportSender extends AbstractHandler implements
                     HTTPConstants.MAX_TOTAL_CONNECTIONS);
 
             HttpConnectionManager connectionManager = new MultiThreadedHttpConnectionManager();
+            
+            connectionManager.getParams().setSoTimeout(soTimeout);
+            connectionManager.getParams().setConnectionTimeout(connectionTimeout);
 
             if (defaultMaxConnectionsPerHostParam != null &&
                     defaultMaxConnectionsPerHostParam.getValue() != null) {


### PR DESCRIPTION
Set connection/socket timeout values to connection manager to use it later..

## Purpose
> Make possible to use timeout values later.

## Goals
> Set connection/socket timeout values to connection manager.

The timeout value is set to a variable, but it is not passed to the Connection manager.

```
            Parameter tempSoTimeoutParam = transportOut
                    .getParameter(HTTPConstants.SO_TIMEOUT);
            Parameter tempConnTimeoutParam = transportOut
                    .getParameter(HTTPConstants.CONNECTION_TIMEOUT);

            if (tempSoTimeoutParam != null) {
                soTimeout = Integer.parseInt((String) tempSoTimeoutParam
                        .getValue());
            }

            if (tempConnTimeoutParam != null) {
                connectionTimeout = Integer
                        .parseInt((String) tempConnTimeoutParam.getValue());
            }
```

So I added parameter setting code..

```
            connectionManager.getParams().setSoTimeout(soTimeout);
            connectionManager.getParams().setConnectionTimeout(connectionTimeout);
```