### PR TITLE
Fix product-ei/issues/2722

### DIFF
--- a/modules/json/src/org/apache/axis2/json/gson/GsonXMLStreamReader.java
+++ b/modules/json/src/org/apache/axis2/json/gson/GsonXMLStreamReader.java
@@ -30,7 +30,6 @@ import org.apache.axis2.json.gson.factory.XmlNodeGenerator;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.ws.commons.schema.XmlSchema;
-
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.namespace.QName;
 import javax.xml.stream.Location;
@@ -672,8 +671,20 @@ public class GsonXMLStreamReader implements XMLStreamReader {
         }
     }
 
-    private void nextName() throws IOException, XMLStreamException {
+    private String bypassRootElement() throws IOException {
         String name = jsonReader.nextName();
+        if (!("request_box".equalsIgnoreCase(name) && schemaList.isEmpty())) {
+            JsonObject jsonObject = schemaList.get(0);
+            if (JsonState.StartState == state || JSONType.NESTED_ARRAY.equals(jsonObject.getType())) {
+                name = jsonObject.getName();
+            }
+        }
+
+        return name;
+    }
+
+    private void nextName() throws IOException, XMLStreamException {
+        String name = bypassRootElement();
         boolean isElementExists = false;
         if (!miniList.isEmpty()) {
             while (!isElementExists && (miniListPointer < miniList.size() || skipMiniListElement)) {

--- a/modules/json/test-resources/custom_schema/testSchema_4.xsd
+++ b/modules/json/test-resources/custom_schema/testSchema_4.xsd
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.w3schools.com"
+           xmlns="http://www.w3schools.com"
+           elementFormDefault="qualified">
+    <xs:element name="_postemployee">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="_postemployee" type="_postemployee"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="_postemployee">
+        <xs:sequence>
+            <xs:element name="employeenumber" type="xs:string" minOccurs="0"/>
+            <xs:element name="firstname" type="xs:string" minOccurs="0"/>
+            <xs:element name="lastname" type="xs:string"/>
+            <xs:element name="email" type="xs:string"/>
+            <xs:element name="salary" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+
+</xs:schema>

--- a/modules/json/test-resources/custom_schema/testSchema_5.xsd
+++ b/modules/json/test-resources/custom_schema/testSchema_5.xsd
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.w3schools.com"
+           xmlns="http://www.w3schools.com"
+           elementFormDefault="qualified">
+
+    <xs:element name="_postemployee_batch_req">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="_postemployee" type="_postemployee" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="_postemployee">
+        <xs:sequence>
+            <xs:element name="_postemployee" type="employee"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="employee">
+        <xs:sequence>
+            <xs:element name="employeenumber" type="xs:string" minOccurs="0"/>
+            <xs:element name="firstname" type="xs:string" minOccurs="0"/>
+            <xs:element name="lastname" type="xs:string"/>
+            <xs:element name="email" type="xs:string"/>
+            <xs:element name="salary" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+
+</xs:schema>

--- a/modules/json/test/org/apache/axis2/json/gson/GsonXMLStreamReaderTest.java
+++ b/modules/json/test/org/apache/axis2/json/gson/GsonXMLStreamReaderTest.java
@@ -35,12 +35,13 @@ import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
 public class GsonXMLStreamReaderTest {
     
-    
+
     @Test
     public void testGsonXMLStreamReader() throws Exception {
         String jsonString = "{\"response\":{\"return\":{\"name\":\"kate\",\"age\":\"35\",\"gender\":\"female\"}}}";
@@ -84,6 +85,112 @@ public class GsonXMLStreamReaderTest {
         List<XmlSchema> schemaList = new ArrayList<XmlSchema>();
         schemaList.add(schema);
         QName elementQName = new QName("http://www.w3schools.com", "response");
+        ConfigurationContext configCtxt = new ConfigurationContext(new AxisConfiguration());
+        GsonXMLStreamReader gsonXMLStreamReader = new GsonXMLStreamReader(jsonReader);
+        gsonXMLStreamReader.initXmlStreamReader(elementQName, schemaList, configCtxt);
+        StAXOMBuilder stAXOMBuilder = new StAXOMBuilder(gsonXMLStreamReader);
+        OMElement omElement = stAXOMBuilder.getDocumentElement();
+        String actual = omElement.toString();
+        inputStream.close();
+        is.close();
+        Assert.assertEquals(xmlString, actual);
+    }
+
+    /**
+     * This method tests GsonXMLStreamReader without the request name ie: request method + request path  which is
+     * required in the schema ( _postemployee ).
+     */
+    @Test
+    public void testGsonXMLStreamReaderSingleRequest() throws Exception {
+
+        String jsonString = "{ \"employee\":" +
+                "{ \"employeenumber\":\"0001\"," +
+                "\"firstname\":\"Steve\"," +
+                "\"lastname\":\"Wilson\"," +
+                "\"email\":\"wilson@Wso2.com\"," +
+                "\"salary\":\"15000.00\"" +
+                "}" +
+                "}";
+
+        String xmlString = "<_postemployee xmlns=\"http://www.w3schools.com\">" +
+                "<employeenumber>0001</employeenumber>" +
+                "<firstname>Steve</firstname>" +
+                "<lastname>Wilson</lastname>" +
+                "<email>wilson@Wso2.com</email>" +
+                "<salary>15000.00</salary>" +
+                "</_postemployee>";
+
+        InputStream inputStream = new ByteArrayInputStream(jsonString.getBytes());
+        JsonReader jsonReader = new JsonReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+        String fileName = "test-resources/custom_schema/testSchema_4.xsd";
+        InputStream is = new FileInputStream(fileName);
+        XmlSchemaCollection schemaCol = new XmlSchemaCollection();
+        XmlSchema schema = schemaCol.read(new StreamSource(is), null);
+        List<XmlSchema> schemaList = new ArrayList<XmlSchema>();
+        schemaList.add(schema);
+        QName elementQName = new QName("http://www.w3schools.com", "_postemployee");
+        ConfigurationContext configCtxt = new ConfigurationContext(new AxisConfiguration());
+        GsonXMLStreamReader gsonXMLStreamReader = new GsonXMLStreamReader(jsonReader);
+        gsonXMLStreamReader.initXmlStreamReader(elementQName, schemaList, configCtxt);
+        StAXOMBuilder stAXOMBuilder = new StAXOMBuilder(gsonXMLStreamReader);
+        OMElement omElement = stAXOMBuilder.getDocumentElement();
+        String actual = omElement.toString();
+        inputStream.close();
+        is.close();
+        Assert.assertEquals(xmlString, actual);
+    }
+
+    /**
+     * This method tests GsonXMLStreamReader without the request name ie: request method + request path which is
+     *required in the schema ( _postemployee_batch_req , _postemployee ).
+     */
+    @Test
+    public void testGsonXMLStreamReaderBatchRequest() throws Exception {
+
+        String jsonString = "{\"employees\": " +
+                "{\"employees\": [" +
+                "{ \"employeenumber\": \"00021\"," +
+                "\"firstname\": \"Will\"," +
+                "\"lastname\": \"Smith\"," +
+                "\"email\": \"will@smith.com\"," +
+                "\"salary\": \"1500.00\"" +
+                "}," +
+                "{ \"employeenumber\": \"00021\"," +
+                "\"firstname\": \"Will\"," +
+                "\"lastname\": \"Smith\"," +
+                "\"email\": \"will@smith.com\"," +
+                "\"salary\": \"1500.00\"" +
+                "}" +
+                "]" +
+                "}" +
+                "}";
+
+        String xmlString = "<_postemployee_batch_req xmlns=\"http://www.w3schools.com\">" +
+                "<_postemployee>" +
+                "<employeenumber>00021</employeenumber>" +
+                "<firstname>Will</firstname>" +
+                "<lastname>Smith</lastname>" +
+                "<email>will@smith.com</email>" +
+                "<salary>1500.00</salary>" +
+                "</_postemployee>" +
+                "<_postemployee>" +
+                "<employeenumber>00021</employeenumber>" +
+                "<firstname>Will</firstname>" +
+                "<lastname>Smith</lastname>" +
+                "<email>will@smith.com</email>" +
+                "<salary>1500.00</salary>" +
+                "</_postemployee>" +
+                "</_postemployee_batch_req>";
+
+        InputStream inputStream = new ByteArrayInputStream(jsonString.getBytes());
+        JsonReader jsonReader = new JsonReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+        String fileName = "test-resources/custom_schema/testSchema_5.xsd";
+        InputStream is = new FileInputStream(fileName);
+        XmlSchemaCollection schemaCol = new XmlSchemaCollection();
+        XmlSchema schema = schemaCol.read(new StreamSource(is), null);
+        List<XmlSchema> schemaList = new ArrayList<XmlSchema>();
+        schemaList.add(schema);
+        QName elementQName = new QName("http://www.w3schools.com", "_postemployee_batch_req");
         ConfigurationContext configCtxt = new ConfigurationContext(new AxisConfiguration());
         GsonXMLStreamReader gsonXMLStreamReader = new GsonXMLStreamReader(jsonReader);
         gsonXMLStreamReader.initXmlStreamReader(elementQName, schemaList, configCtxt);


### PR DESCRIPTION
## Purpose
> It is required that the request method and resource to be included in the payload body when a JSON payload is sent to a dataservice. Only if the exact request path is available in the payload then only the payload will be executed.(_postemployee_batch_req,_postemployee).
JSON payload is taken as an input stream and sent to GsonStreamReader , reading of values and validation of payload takes place here. JSON payload is validated against a schema which contains the format for the json payload.
When the element name is change than that of the schema validation fails and the operation breaks at GsonStreamReader.

Resolves: https://github.com/wso2/product-ei/issues/2722
## Goals
>Allow the payload to be executed without the requirement of request name to be available in the json payload ie: allow payload to be executed regardless of what is included at the top element of the json payload. eg : use "employee" instead of "_postemployee".

## Approach
> By passed user input of the top element of json payload and returned the top element name which is contained in the schema when the request made is not a request box request 
 
## User stories
>
## Release note
> 
## Documentation
>
## Training
>

## Certification
> 

## Marketing
> 
## Automation tests
 - Unit tests 
   >
 - Integration tests
   >Tested for single dataservice request with json payload
Tested for batch dataservice request with json payload

## Security checks


## Samples
> 

## Related PRs
> 

## Migrations (if applicable)
> 

## Test environment
>
## Learning
> 