### PR TITLE
Add maven-surefire version to orbit pom file

### DIFF
--- a/orbit/axis2-client/pom.xml
+++ b/orbit/axis2-client/pom.xml
@@ -333,6 +333,11 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+            </plugin>
         </plugins>
     </build>
 
@@ -350,5 +355,6 @@
         <version.apache.felix.framework>1.4.0</version.apache.felix.framework>
         <xmlbeans.version>2.3.0</xmlbeans.version>
         <orbit.version.neethi>2.0.4.wso2v5</orbit.version.neethi>
+        <maven.surefire.plugin.version>2.13</maven.surefire.plugin.version>
     </properties>
 </project>

--- a/orbit/axis2-jaxbri/pom.xml
+++ b/orbit/axis2-jaxbri/pom.xml
@@ -108,10 +108,16 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+            </plugin>
         </plugins>
     </build>
     <properties>
         <version.axis2>1.6.1-wso2v29-SNAPSHOT</version.axis2>
         <exp.pkg.version.axis2>${version.axis2}</exp.pkg.version.axis2>
+        <maven.surefire.plugin.version>2.13</maven.surefire.plugin.version>
     </properties>
 </project>

--- a/orbit/axis2-json/pom.xml
+++ b/orbit/axis2-json/pom.xml
@@ -106,10 +106,16 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+            </plugin>
         </plugins>
     </build>
     <properties>
         <version.axis2.json>1.6.1-wso2v29-SNAPSHOT</version.axis2.json>
         <exp.pkg.version.axis2>${version.axis2.json}</exp.pkg.version.axis2>
+        <maven.surefire.plugin.version>2.13</maven.surefire.plugin.version>
     </properties>
 </project>

--- a/orbit/axis2/pom.xml
+++ b/orbit/axis2/pom.xml
@@ -563,6 +563,11 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+            </plugin>
         </plugins>
     </build>
 
@@ -576,6 +581,7 @@
         <version.apache.felix.framework>1.4.0</version.apache.felix.framework>
         <xmlbeans.version>2.3.0</xmlbeans.version>
         <orbit.version.neethi>2.0.4.wso2v5</orbit.version.neethi>
+        <maven.surefire.plugin.version>2.13</maven.surefire.plugin.version>
     </properties>
 
 </project>


### PR DESCRIPTION
## Purpose
Fix the build break due to maven-surefire version

## Goals
Fix the build break due to maven-surefire version

## Approach
Set a compatible maven-surefire version.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   N/A
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A