### PR TITLE
Fix: wso2/product-ei#2722

### DIFF
--- a/modules/json/src/org/apache/axis2/json/gson/GsonXMLStreamReader.java
+++ b/modules/json/src/org/apache/axis2/json/gson/GsonXMLStreamReader.java
@@ -673,7 +673,7 @@ public class GsonXMLStreamReader implements XMLStreamReader {
 
     private String bypassRootElement() throws IOException {
         String name = jsonReader.nextName();
-        if (!("request_box".equalsIgnoreCase(name) && schemaList.isEmpty())) {
+        if (!(("request_box").equals(this.elementQname.getLocalPart())) && !schemaList.isEmpty()) {
             JsonObject jsonObject = schemaList.get(0);
             if (JsonState.StartState == state || JSONType.NESTED_ARRAY.equals(jsonObject.getType())) {
                 name = jsonObject.getName();


### PR DESCRIPTION
Bypassed root element of JSON payload to contain the name in the xml
schema, therefore the user can enter any string value for root element
and for child element of batch request.This fix dosen't bypass the name
for request box.

Fixes: https://github.com/wso2/product-ei/issues/2722

## Purpose
It is required that the request method and resource to be included in the payload body when a JSON payload is sent to a dataservice. Only if the exact request path is available in the payload then only the payload will be executed.(_postemployee_batch_req,_postemployee).
JSON payload is taken as an input stream and sent to GsonStreamReader , reading of values and validation of payload takes place here. JSON payload is validated against a schema which contains the format for the json payload.
When the element name is change than that of the schema validation fails and the operation breaks at GsonStreamReader.

## Goals
Allow the payload to be executed without the requirement of request name to be available in the json payload ie: allow payload to be executed regardless of what is included at the top element of the json payload. eg : use "employee" instead of "_postemployee".

## Approach
By passed user input of the top element of json payload and returned the top element name which is contained in the schema when the request made is not a request box request.

## Automation tests
 
 - Integration tests
   Tested for single dataservice request with json payload
Tested for batch dataservice request with json payload
