### PR TITLE
 Add javax.activation dependency

### DIFF
--- a/orbit/axis2-client/pom.xml
+++ b/orbit/axis2-client/pom.xml
@@ -288,7 +288,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>org.wso2.orbit.javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>${orbit.activation.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -352,6 +356,7 @@
         <securevault.version>1.0.0</securevault.version>
         <orbit.version.commons.fileuploader>1.3.1.wso2v1</orbit.version.commons.fileuploader>
         <orbit.version.spring>3.1.0.wso2v3</orbit.version.spring>
+        <orbit.activation.version>1.1.1.wso2v1</orbit.activation.version>
         <version.apache.felix.framework>1.4.0</version.apache.felix.framework>
         <xmlbeans.version>2.3.0</xmlbeans.version>
         <orbit.version.neethi>2.0.4.wso2v5</orbit.version.neethi>


### PR DESCRIPTION
## Purpose
From onwards java 11 the javax.activation package has been removed from the runtime. This dependency is needed during the stub file generation. 

## Goals
 Add javax.activation dependency


merge after : https://github.com/wso2/orbit/pull/339