### PR TITLE
Fix wso2/product-ei/issues/3062

### DIFF
--- a/modules/kernel/src/org/apache/axis2/util/Utils.java
+++ b/modules/kernel/src/org/apache/axis2/util/Utils.java
@@ -269,7 +269,7 @@ public class Utils {
         	servicePath = servicePath+"/";
         }
 
-        int index = path.lastIndexOf(servicePath);
+        int index = path.indexOf(servicePath);
         String serviceOpPart = null;
 
         if (-1 != index) {


### PR DESCRIPTION
## Purpose
> It is not possible to invoke a proxy service using /services/proxyName/services/xxx url because of the 2nd "services" wording within url. It will only invoke the default main sequence.
The issue is with the check where it takes the lastIndexOf the "/services/". Fix it for taking the index of the first occurrence using "indexOf" method.

