### PR TITLE
Add a custom annotation to skip null values.

### DIFF
--- a/modules/adb/src/org/apache/axis2/databinding/annotation/IgnoreNullElement.java
+++ b/modules/adb/src/org/apache/axis2/databinding/annotation/IgnoreNullElement.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.axis2.databinding.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ *  Ignore a property with a null value when creating the response if the IgnoreNullElement annotation is used to
+ *  declare the property.
+ *
+ *  <b>Example </b>
+ *    <pre>
+ *     //Example: Code fragment
+ *     public class Person {
+ *         &#64;IgnoreNullElement
+ *         String name;
+ *     }
+ *   </pre>
+ */
+
+@Retention(RUNTIME)
+@Target({FIELD})
+public @interface IgnoreNullElement {
+
+}

--- a/modules/kernel/src/org/apache/axis2/Constants.java
+++ b/modules/kernel/src/org/apache/axis2/Constants.java
@@ -472,5 +472,10 @@ public class Constants extends org.apache.axis2.namespace.Constants {
          *  This parameter enables message exchange pattern in and out for the Axis operation.
          */
         public static final String GET_HTTP_SC_OK_FOR_VOID_SERVICE_METHODS = "mepinandout";
+
+        /**
+         * Axis2.xml property to force include null values.
+         */
+        public static final String ENABLE_FORCE_INCLUDE_NULL_ELEMENTS = "forceIncludeNullElements";
     }
 }

--- a/modules/transport/http/pom.xml
+++ b/modules/transport/http/pom.xml
@@ -99,6 +99,12 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.axis2</groupId>
+            <artifactId>axis2-adb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/modules/transport/http/src/org/apache/axis2/transport/http/AxisServlet.java
+++ b/modules/transport/http/src/org/apache/axis2/transport/http/AxisServlet.java
@@ -51,6 +51,7 @@ import org.apache.axis2.transport.http.util.RESTUtil;
 import org.apache.axis2.util.JavaUtils;
 import org.apache.axis2.util.MessageContextBuilder;
 import org.apache.axis2.util.OnDemandLogger;
+import org.apache.axis2.databinding.utils.BeanUtil;
 import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 
 import javax.servlet.ServletConfig;
@@ -557,6 +558,15 @@ public class AxisServlet extends HttpServlet {
         if (parameter != null) {
             closeReader = JavaUtils.isTrueExplicitly(parameter.getValue());
         }
+
+        // Read property "forceIncludeNullElements" in axis2.xml class.
+        boolean forceIncludeNullElements = false;
+        Parameter isForceIncludeNullElements = axisConfiguration.getParameter(Constants.Configuration.
+                ENABLE_FORCE_INCLUDE_NULL_ELEMENTS);
+        if (isForceIncludeNullElements != null) {
+                forceIncludeNullElements = JavaUtils.isTrueExplicitly(isForceIncludeNullElements.getValue());
+        }
+        BeanUtil.setIsForceIncludeNullElements(forceIncludeNullElements);
 
     }
 


### PR DESCRIPTION
## Purpose

When a new attribute is added to an Admin Service (WSDL) then the existing clients that have not regenerated the stub will get an error "Unexpected Subelement" when trying to access a service that will return the new attribute.

## Goals
Introduce a new annotation that will skip null values after chacking a system property. For clients who do not need to skip null values can assign the new system property in the server startup.

## Approach
- Add a custom annotation `IgnoreNullElement` to skip null values.

- Check the annotation and a system property `forceIncludeNullElements` when creating the `PropertyQnameList`.

- If the property value is null, `IgnoreNullElement` annotation is set and the `forceIncludeNullElements` is not set then skip  adding the property in the `PropertyQnameList`.