### PR TITLE
Fix wso2/product-apim#5091

### DIFF
--- a/modules/kernel/src/org/apache/axis2/util/MessageProcessorSelector.java
+++ b/modules/kernel/src/org/apache/axis2/util/MessageProcessorSelector.java
@@ -246,7 +246,7 @@ public class MessageProcessorSelector {
          * change content type of current message.
          */
         String cType = type;
-        if (msgContext.isDoingREST() && HTTPConstants.MEDIA_TYPE_TEXT_XML.equals(type)) {
+        if (msgContext.isDoingREST() && HTTPConstants.MEDIA_TYPE_TEXT_XML.equals(type) && msgContext.getSoapAction() == null) {
             cType = HTTPConstants.MEDIA_TYPE_APPLICATION_XML;
             if (msgContext.getProperty(Constants.Configuration.CONTENT_TYPE) == null) {
                 msgContext.setProperty(Constants.Configuration.CONTENT_TYPE, HTTPConstants.MEDIA_TYPE_TEXT_XML);


### PR DESCRIPTION
## Purpose
This PR fixes the issue of the response payload dropping the soap headers when the request content type is application/xml and JMS backend response type is text/xml.

Fix wso2/product-apim#5091
