### PR TITLE
Change javax.xml.soap import-package version

### DIFF
--- a/orbit/axis2/pom.xml
+++ b/orbit/axis2/pom.xml
@@ -546,7 +546,7 @@
                             javax.servlet; version="${imp.pkg.version.javax.servlet}",
                             javax.servlet.http; version="${imp.pkg.version.javax.servlet}",
                             javax.xml.stream.*; version="1.0.1",
-                            javax.xml.soap.*; version="1.0.0",
+                            javax.xml.soap.*; version="0.0.0",
                             org.apache.commons.io.*; version="0.0.0",
                             javax.mail.*; version="1.4.0",
                             javax.wsdl.*; version="1.6.2",


### PR DESCRIPTION
This fix the issue - https://github.com/wso2/product-is/issues/6770
> Our intention is to move both javax.xml.soap and com.sun.xml move to same class loader lib