### PR TITLE
Update replaceSystemProperty method to support resolving $env and $sys

### DIFF
--- a/modules/kernel/src/org/apache/axis2/Constants.java
+++ b/modules/kernel/src/org/apache/axis2/Constants.java
@@ -330,7 +330,7 @@ public class Constants extends org.apache.axis2.namespace.Constants {
      */
     public static final String SYS_PROPERTY_PLACEHOLDER_PREFIX = "$sys{";
     public static final String ENV_VAR_PLACEHOLDER_PREFIX = "$env{";
-    public static final String PROPERTY_PLACEHOLDER_PREFIX = "${";
+    public static final String DYNAMIC_PROPERTY_PLACEHOLDER_PREFIX = "${";
     public static final String PLACEHOLDER_SUFFIX = "}";
 
     public static interface Configuration {

--- a/modules/kernel/src/org/apache/axis2/Constants.java
+++ b/modules/kernel/src/org/apache/axis2/Constants.java
@@ -325,6 +325,14 @@ public class Constants extends org.apache.axis2.namespace.Constants {
 
     public static final String CUSTOM_SCHEMA_NAME_PREFIX ="customSchemaNamePrefix" ;
 
+    /**
+     * Constants used to resolve environment variables and system properties
+     */
+    public static final String SYS_PROPERTY_PLACEHOLDER_PREFIX = "$sys{";
+    public static final String ENV_VAR_PLACEHOLDER_PREFIX = "$env{";
+    public static final String PROPERTY_PLACEHOLDER_PREFIX = "${";
+    public static final String PLACEHOLDER_SUFFIX = "}";
+
     public static interface Configuration {
         public static final String ENABLE_REST = "enableREST";
         public static final String ENABLE_HTTP_CONTENT_NEGOTIATION = "httpContentNegotiation";

--- a/modules/kernel/src/org/apache/axis2/deployment/DescriptionBuilder.java
+++ b/modules/kernel/src/org/apache/axis2/deployment/DescriptionBuilder.java
@@ -61,7 +61,7 @@ import java.util.regex.Pattern;
 
 import static org.apache.axis2.Constants.ENV_VAR_PLACEHOLDER_PREFIX;
 import static org.apache.axis2.Constants.PLACEHOLDER_SUFFIX;
-import static org.apache.axis2.Constants.PROPERTY_PLACEHOLDER_PREFIX;
+import static org.apache.axis2.Constants.DYNAMIC_PROPERTY_PLACEHOLDER_PREFIX;
 import static org.apache.axis2.Constants.SYS_PROPERTY_PLACEHOLDER_PREFIX;
 
 /**
@@ -708,7 +708,7 @@ public class DescriptionBuilder implements DeploymentConstants {
                 if (StringUtils.isNotEmpty(property)) {
                     text = text.replaceAll(Pattern.quote(SYS_PROPERTY_PLACEHOLDER_PREFIX + ref + PLACEHOLDER_SUFFIX), property);
                 } else {
-                    throw new RuntimeException("Error while retrieving " + ref + " system property");
+                    log.warn("System property is not available for " + ref);
                 }
             }
             return text;
@@ -720,7 +720,7 @@ public class DescriptionBuilder implements DeploymentConstants {
                 if (StringUtils.isNotEmpty(resolvedValue)) {
                     text = text.replaceAll(Pattern.quote(ENV_VAR_PLACEHOLDER_PREFIX + ref + PLACEHOLDER_SUFFIX), resolvedValue);
                 } else {
-                    throw new RuntimeException("Error while retrieving " + ref + " environment variable");
+                    log.warn("Environment variable is not available for " + ref);
                 }
             }
             return text;
@@ -732,8 +732,8 @@ public class DescriptionBuilder implements DeploymentConstants {
         // The following condition deals with properties.
         // Properties are specified as ${system.property},
         // and are assumed to be System properties
-        while (indexOfStartingChars < text.indexOf(PROPERTY_PLACEHOLDER_PREFIX)
-                && (indexOfStartingChars = text.indexOf(PROPERTY_PLACEHOLDER_PREFIX)) != -1
+        while (indexOfStartingChars < text.indexOf(DYNAMIC_PROPERTY_PLACEHOLDER_PREFIX)
+                && (indexOfStartingChars = text.indexOf(DYNAMIC_PROPERTY_PLACEHOLDER_PREFIX)) != -1
                 && (indexOfClosingBrace = text.indexOf(PLACEHOLDER_SUFFIX)) != -1) {
             String sysProp = text.substring(indexOfStartingChars + 2,
                     indexOfClosingBrace);

--- a/modules/kernel/src/org/apache/axis2/deployment/DescriptionBuilder.java
+++ b/modules/kernel/src/org/apache/axis2/deployment/DescriptionBuilder.java
@@ -698,30 +698,26 @@ public class DescriptionBuilder implements DeploymentConstants {
     }
 
     protected String replaceSystemProperty(String text) {
-        String[] sysRefs = StringUtils.substringsBetween(text, SYS_PROPERTY_PLACEHOLDER_PREFIX, PLACEHOLDER_SUFFIX);
-        String[] envRefs = StringUtils.substringsBetween(text, ENV_VAR_PLACEHOLDER_PREFIX, PLACEHOLDER_SUFFIX);
+        String sysRefs = StringUtils.substringBetween(text, SYS_PROPERTY_PLACEHOLDER_PREFIX, PLACEHOLDER_SUFFIX);
+        String envRefs = StringUtils.substringBetween(text, ENV_VAR_PLACEHOLDER_PREFIX, PLACEHOLDER_SUFFIX);
 
         // Resolves system property references ($sys{ref}) in an individual string.
         if (sysRefs != null) {
-            for (String ref : sysRefs) {
-                String property = System.getProperty(ref);
-                if (StringUtils.isNotEmpty(property)) {
-                    text = text.replaceAll(Pattern.quote(SYS_PROPERTY_PLACEHOLDER_PREFIX + ref + PLACEHOLDER_SUFFIX), property);
-                } else {
-                    log.warn("System property is not available for " + ref);
-                }
+            String property = System.getProperty(sysRefs);
+            if (StringUtils.isNotEmpty(property)) {
+                text = text.replaceAll(Pattern.quote(SYS_PROPERTY_PLACEHOLDER_PREFIX + sysRefs + PLACEHOLDER_SUFFIX), property);
+            } else {
+                log.error("System property is not available for " + sysRefs);
             }
             return text;
         }
         // Resolves environment variable references ($env{ref}) in an individual string.
         if (envRefs != null) {
-            for (String ref : envRefs) {
-                String resolvedValue = System.getenv(ref);
-                if (StringUtils.isNotEmpty(resolvedValue)) {
-                    text = text.replaceAll(Pattern.quote(ENV_VAR_PLACEHOLDER_PREFIX + ref + PLACEHOLDER_SUFFIX), resolvedValue);
-                } else {
-                    log.warn("Environment variable is not available for " + ref);
-                }
+            String resolvedValue = System.getenv(envRefs);
+            if (StringUtils.isNotEmpty(resolvedValue)) {
+                text = text.replaceAll(Pattern.quote(ENV_VAR_PLACEHOLDER_PREFIX + envRefs + PLACEHOLDER_SUFFIX), resolvedValue);
+            } else {
+                log.error("Environment variable is not available for " + envRefs);
             }
             return text;
         }


### PR DESCRIPTION
## Purpose
> This PR updates the replaceSystemProperty() method. The environment variables can be defined as $env{ref} and the system properties can be defined as $sys{ref} in axis2 configuration.