### PR TITLE
Fix: https://github.com/wso2/product-ei/issues/5047

### DIFF
--- a/modules/transport/base/src/main/java/org/apache/axis2/transport/base/IgnoreSuspensionBaseTransportException.java
+++ b/modules/transport/base/src/main/java/org/apache/axis2/transport/base/IgnoreSuspensionBaseTransportException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.axis2.transport.base;
+
+public class IgnoreSuspensionBaseTransportException extends BaseTransportException {
+    public IgnoreSuspensionBaseTransportException(String msg) {
+        super(msg);
+    }
+
+    public IgnoreSuspensionBaseTransportException(String msg, Exception e) {
+        super(msg, e);
+    }
+}


### PR DESCRIPTION
## Purpose
The JMS endpoints in request-response service (JMS dual-channel proxy service )
will immediately suspend when it receives a malformed JMS message (The type which).
Fix this by introducing a new error_code 101550. To differentiate this in synapse level
this new exception is introduced

Related: https://github.com/wso2/product-ei/issues/5047s