### PR TITLE
Introduce "internalTransaction" property to the message context

### DIFF
--- a/modules/transport/base/src/main/java/org/apache/axis2/transport/base/BaseConstants.java
+++ b/modules/transport/base/src/main/java/org/apache/axis2/transport/base/BaseConstants.java
@@ -131,5 +131,8 @@ public class BaseConstants {
     /** A message level property indicating a request to rollback the transaction associated with the message */
     public static final String SET_ROLLBACK_ONLY = "SET_ROLLBACK_ONLY";
     /** A message level property indicating a commit is required after the next immidiate send over a transport */
-    public static final String JTA_COMMIT_AFTER_SEND = "JTA_COMMIT_AFTER_SEND";    
+    public static final String JTA_COMMIT_AFTER_SEND = "JTA_COMMIT_AFTER_SEND";
+
+    /** The message context property name which holds the transaction is counted internally or not */
+    public static final String INTERNAL_TRANSACTION_COUNTED = "INTERNAL_TRANSACTION_COUNTED";
 }


### PR DESCRIPTION
## Purpose
For the use of the Transaction counting mechanism, a new property called "INTERNAL_TRANSACTION_COUNTED" is introduced, which will be checked by the "handleRequestInFlow(MessageContext messageContext)" method inside the synapse handler called "TransactionHandler". If the property is already there in the request with the relevant value, the transaction will be counted.