### PR TITLE
Fix for wso2/wso2-axis2#211

### DIFF
--- a/modules/transport/http/src/org/apache/axis2/transport/http/HTTPSender.java
+++ b/modules/transport/http/src/org/apache/axis2/transport/http/HTTPSender.java
@@ -308,6 +308,16 @@ public class HTTPSender extends AbstractHTTPSender {
         }
 
         String soapAction = messageFormatter.formatSOAPAction(msgContext, format, soapActionString);
+
+        Object followRedirect = msgContext.getProperty("FOLLOW_REDIRECT");
+        Object cookieStatus = msgContext.getProperty("DISABLE_COOKIE");
+
+        if (followRedirect != null) {
+            patchMethod.setFollowRedirects(Boolean.parseBoolean(followRedirect.toString()));
+        }
+        if (cookieStatus != null && (Boolean.parseBoolean(cookieStatus.toString()))) {
+            patchMethod.getParams().setCookiePolicy(CookiePolicy.IGNORE_COOKIES);
+        }
         if (soapAction != null && !msgContext.isDoingREST()) {
             patchMethod.setRequestHeader(HTTPConstants.HEADER_SOAP_ACTION, soapAction);
         }


### PR DESCRIPTION
## Purpose
Resolves wso2/wso2-axis2#211

## User stories
Use following property to avoid sending cookie headers along with the request.
```
<property name="DISABLE_COOKIE" value="true" scope="axis2" type="BOOLEAN"/>
```
## Release note
Support for `DISABLE_COOKIE` property for `PATCH` requests

## Documentation
https://github.com/wso2/docs-ei/issues/1600