### PR TITLE
Fix issue when empty payload returned with 201 status code

### DIFF
--- a/modules/kernel/src/org/apache/axis2/description/OutInAxisOperation.java
+++ b/modules/kernel/src/org/apache/axis2/description/OutInAxisOperation.java
@@ -46,9 +46,13 @@ import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import javax.xml.namespace.QName;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PushbackInputStream;
 import java.util.HashMap;
 import java.util.Map;
+
+import javax.xml.namespace.QName;
 
 public class OutInAxisOperation extends TwoChannelAxisOperation {
 
@@ -597,7 +601,21 @@ class OutInAxisOperationClient extends OperationClient {
      */
     private boolean canResponseHaveBody(MessageContext responseMessageContext) {
         if (responseMessageContext.getProperty("transport.http.statusCode") != null) {
-            int statusCode = Integer.parseInt(responseMessageContext.getProperty("transport.http.statusCode").toString());
+            int statusCode =
+                    Integer.parseInt(responseMessageContext.getProperty("transport.http.statusCode").toString());
+            if (statusCode == HttpStatus.SC_CREATED || statusCode == HttpStatus.SC_ACCEPTED) {
+                InputStream inputStream = (InputStream) responseMessageContext.getProperty(MessageContext.TRANSPORT_IN);
+                PushbackInputStream pushbackInputStream = new PushbackInputStream(inputStream);
+                int data = 0;
+                try {
+                    data = pushbackInputStream.read();
+                    pushbackInputStream.unread(data);
+                } catch (IOException e) {
+                    return false;
+                }
+                responseMessageContext.setProperty(MessageContext.TRANSPORT_IN, pushbackInputStream);
+                return data != -1;
+            }
             return statusCode >= HttpStatus.SC_OK
                     && statusCode != HttpStatus.SC_NO_CONTENT
                     && statusCode != HttpStatus.SC_NOT_MODIFIED


### PR DESCRIPTION


## Purpose
Fix this issue by reading ahead one byte from the input stream and
decide whether it is empty or not prior to building
(when 201 and 202 returns as response HTTP status code).

Fixes: https://github.com/wso2/product-ei/issues/5251
Fixes: https://github.com/wso2/product-ei/issues/4811
Alter fix for https://github.com/wso2/product-ei/issues/4695