### PR TITLE
Update PR https://github.com/wso2/wso2-axis2/pull/225

### DIFF
--- a/modules/kernel/src/org/apache/axis2/description/OutInAxisOperation.java
+++ b/modules/kernel/src/org/apache/axis2/description/OutInAxisOperation.java
@@ -603,7 +603,7 @@ class OutInAxisOperationClient extends OperationClient {
         if (responseMessageContext.getProperty("transport.http.statusCode") != null) {
             int statusCode =
                     Integer.parseInt(responseMessageContext.getProperty("transport.http.statusCode").toString());
-            if (statusCode == HttpStatus.SC_CREATED || statusCode == HttpStatus.SC_ACCEPTED || statusCode == HttpStatus.SC_OK) {
+            if (statusCode == HttpStatus.SC_CREATED || statusCode == HttpStatus.SC_ACCEPTED) {
                 InputStream inputStream = (InputStream) responseMessageContext.getProperty(MessageContext.TRANSPORT_IN);
                 PushbackInputStream pushbackInputStream = new PushbackInputStream(inputStream);
                 int data = 0;


### PR DESCRIPTION
## Purpose
This PR removes HTTP Status code 200 from the canResponseHaveBody method that was introduced from the PR https://github.com/wso2/wso2-axis2/pull/225

We will be introducing a configuration element to allow HTTP status code 200 empty body response (in blocking mode).
