### PR TITLE
Fixing the Content-Type is being sent as "charset" for binary content-types like application/pdf

### DIFF
--- a/modules/integration/test/org/apache/axis2/transport/http/MultipartFormDataFormatterTest.java
+++ b/modules/integration/test/org/apache/axis2/transport/http/MultipartFormDataFormatterTest.java
@@ -93,4 +93,32 @@ public class MultipartFormDataFormatterTest extends TestCase {
 
         assertEquals(fileContent, content);
     }
+
+    public void testContentTypeApplicationPdfWithoutCharset() throws Exception {
+        MultipartFormDataFormatter formatter = new MultipartFormDataFormatter();
+        MessageContext mc = new MessageContext();
+        SOAPFactory factory = OMAbstractFactory.getSOAP11Factory();
+        SOAPEnvelope defaultEnvelope = factory.getDefaultEnvelope();
+
+        OMElement rootElement = factory.createOMElement("root", null);
+        OMElement partKeyElement = factory.createOMElement("filename", null);
+        partKeyElement.addAttribute("filename", "sample-file.pdf", null);
+        partKeyElement.addAttribute("content-type", "application/pdf", null);
+        rootElement.addChild(partKeyElement);
+
+        defaultEnvelope.getBody().addChild(rootElement);
+
+        mc.setEnvelope(defaultEnvelope);
+
+        OMOutputFormat format = new OMOutputFormat();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        formatter.writeTo(mc, format, baos, true);
+
+        MimeMultipart mp = new MimeMultipart(new ByteArrayDataSource(baos.toByteArray(), format.getContentType()));
+
+        assertEquals(1, mp.getCount());
+        BodyPart bodyPart = mp.getBodyPart(0);
+        assertEquals("sample-file.pdf", bodyPart.getFileName());
+        assertEquals("application/pdf; charset=ISO-8859-1", bodyPart.getContentType());
+    }
 }

--- a/modules/kernel/src/org/apache/axis2/builder/BuilderUtil.java
+++ b/modules/kernel/src/org/apache/axis2/builder/BuilderUtil.java
@@ -421,6 +421,12 @@ public class BuilderUtil {
     public static String extractCharSetValue(String contentType) {
         int index = contentType.indexOf(HTTPConstants.CHAR_SET_ENCODING);
 
+        // When the charset not includes in the content type, the charset
+        // will be set to DEFAULT_CHARSET in createMultipatFormDataRequest function
+        if (index == -1) {
+            return null;
+        }
+
         // If there are spaces around the '=' sign
         int indexOfEq = contentType.indexOf("=", index);
 

--- a/modules/kernel/src/org/apache/axis2/transport/http/MultipartFormDataFormatter.java
+++ b/modules/kernel/src/org/apache/axis2/transport/http/MultipartFormDataFormatter.java
@@ -37,6 +37,8 @@ import org.apache.commons.httpclient.methods.multipart.ByteArrayPartSource;
 import org.apache.commons.httpclient.methods.multipart.FilePart;
 import org.apache.commons.httpclient.methods.multipart.Part;
 import org.apache.commons.httpclient.methods.multipart.StringPart;
+import org.apache.axis2.builder.BuilderUtil;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -272,7 +274,7 @@ public class MultipartFormDataFormatter implements MessageFormatter {
                             DEFAULT_CONTENT_TYPE);
                     String charset = BuilderUtil.extractCharSetValue(contentType);
 
-                    if (charset.isEmpty()) {
+                    if (StringUtils.isEmpty(charset)) {
                         charset = getAttributeValue(ele.getAttribute(CHARSET_ATTRIBUTE_QNAME), DEFAULT_CHARSET);
                     } else {
                         // charset has been included to content type header and there can be situations where
@@ -314,7 +316,8 @@ public class MultipartFormDataFormatter implements MessageFormatter {
                         }
                     }
                     if (part == null) {
-                        String charset = getAttributeValue(ele.getAttribute(CHARSET_ATTRIBUTE_QNAME), "US-ASCII");
+                        String charset = getAttributeValue(ele.getAttribute(CHARSET_ATTRIBUTE_QNAME),
+                                "US-ASCII");
                         if (ele.getQName().getPrefix() != null && !ele.getQName().getPrefix().isEmpty()) {
                             part = new StringPart(ele.getQName().getPrefix() + ":" + ele.getQName().getLocalPart(),
                                     ele.getText(), charset);


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/12361

## Goals
Fixing the Content-Type is being sent as "charset" for binary content-types like application/pdf (which does not have a direct charset associated with it)

## Approach
When the charset is not included in the content type, the charset will be set to DEFAULT_CHARSET in createMultipatFormDataRequest function