### PR TITLE
Fix changing Content-Type when build the message before sending to the backend

### DIFF
--- a/modules/kernel/src/org/apache/axis2/builder/BuilderUtil.java
+++ b/modules/kernel/src/org/apache/axis2/builder/BuilderUtil.java
@@ -92,6 +92,10 @@ public class BuilderUtil {
      * Default content-type used in the file fields
      */
     private static final String DEFAULT_CONTENT_TYPE = "text/plain";
+    /**
+     * Reserved XML element name for content-type
+     */
+    private static final String CONTENT_TYPE = "content-type";
 
     public static SOAPEnvelope buildsoapMessage(MessageContext messageContext,
                                                 MultipleEntryHashMap requestParameterMap,
@@ -228,18 +232,22 @@ public class BuilderUtil {
             DataSource dataSource = dataHandler.getDataSource();
             omElement.addAttribute("filename", dataSource.getName(), ns);
             if (dataSource.getContentType() != null) {
-                omElement.addAttribute("content-type", dataSource.getContentType(), ns);
+                omElement.addAttribute(CONTENT_TYPE, dataSource.getContentType(), ns);
             } else {
-                omElement.addAttribute("content-type", DEFAULT_CONTENT_TYPE, ns);
+                omElement.addAttribute(CONTENT_TYPE, DEFAULT_CONTENT_TYPE, ns);
             }
             omElement.addAttribute("filename", ((DataHandler) parameter).getDataSource().getName(), ns);
         } else if (parameter instanceof Map) {
             HashMap textParameterObj = (HashMap) parameter;
             String testVal = (String) textParameterObj.get("value");
             String charsetVal = (String) textParameterObj.get("charset");
+            String partContentType = (String) textParameterObj.get("contentType");
             OMElement omElement = soapFactory.createOMElement(key, ns, bodyFirstChild);
             omElement.setText(testVal);
             omElement.addAttribute("charset", charsetVal, ns);
+            if (partContentType != null) {
+                omElement.addAttribute(CONTENT_TYPE, partContentType, ns);
+            }
         } else {
             String textValue = parameter.toString();
             soapFactory.createOMElement(key, ns, bodyFirstChild).setText(

--- a/modules/kernel/src/org/apache/axis2/builder/MultipartFormDataBuilder.java
+++ b/modules/kernel/src/org/apache/axis2/builder/MultipartFormDataBuilder.java
@@ -155,8 +155,11 @@ public class MultipartFormDataBuilder implements Builder {
             textValue = new String(diskFileItem.get(), encoding);
         }
 
+        String partContentType = diskFileItem.getContentType();
+
         textParameterMap.put("value", textValue);
         textParameterMap.put("charset", encoding);
+        textParameterMap.put("contentType", partContentType);
         return textParameterMap;
     }
 

--- a/modules/kernel/src/org/apache/axis2/transport/http/MultipartFormDataFormatter.java
+++ b/modules/kernel/src/org/apache/axis2/transport/http/MultipartFormDataFormatter.java
@@ -325,6 +325,9 @@ public class MultipartFormDataFormatter implements MessageFormatter {
                                     ele.getText(), charset);
                         } else {
                             part = new StringPart(ele.getQName().getLocalPart(), ele.getText(), charset);
+                            if (ele.getAttributeValue(CONTENT_TYPE_ATTRIBUTE_QNAME) != null) {
+                                ((StringPart) part).setContentType(ele.getAttributeValue(CONTENT_TYPE_ATTRIBUTE_QNAME));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
### Purpose
To fix changing the Content-Type when building the message before sending it to the backend.

### Goal
Fixes: https://github.com/wso2/api-manager/issues/120

### Approach
Introduced a new attribute from MultipartFormDataBuilder