### PR TITLE
Set transport headers map case insensitive in CommonsTransportHeaders class

### DIFF
--- a/modules/integration/test/org/apache/axis2/transport/http/CommonsTransportHeadersTest.java
+++ b/modules/integration/test/org/apache/axis2/transport/http/CommonsTransportHeadersTest.java
@@ -24,7 +24,7 @@ import org.apache.commons.httpclient.Header;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.HashMap;
+import java.util.Map;
 
 public class CommonsTransportHeadersTest extends TestCase {
     Header[] headers;
@@ -51,7 +51,7 @@ public class CommonsTransportHeadersTest extends TestCase {
         initHeaders();
         // This is to get init() method called.
         commonsTransportHeaders.isEmpty();
-        HashMap headerMap = commonsTransportHeaders.headerMap;
+        Map headerMap = commonsTransportHeaders.headerMap;
         Assert.assertTrue(headerMap.containsKey("name"));
         Assert.assertEquals(headerMap.get("name"), value);
     }

--- a/modules/transport/http/src/org/apache/axis2/transport/http/CommonsTransportHeaders.java
+++ b/modules/transport/http/src/org/apache/axis2/transport/http/CommonsTransportHeaders.java
@@ -22,21 +22,26 @@ package org.apache.axis2.transport.http;
 import org.apache.commons.httpclient.Header;
 
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 public class CommonsTransportHeaders implements Map {
     private Header[] headers;
 
-    HashMap headerMap = null;
+    Map headerMap = null;
 
     public CommonsTransportHeaders(Header[] headers) {
         this.headers = headers;
     }
 
     private void init() {
-        headerMap = new HashMap();
+        headerMap = new TreeMap<String, String>(new Comparator<String>() {
+            public int compare(String o1, String o2) {
+                return o1.compareToIgnoreCase(o2);
+            }
+        });
         for (int i = 0; i < headers.length; i++) {
             if (headerMap.containsKey(headers[i].getName())) {
                 String headerValue = (String) headerMap.get(headers[i].getName());


### PR DESCRIPTION
Use of `java.util.TreeMap` over `java.util.HashMap` to avoid header values getting overwritten by others. 
Related issue: https://github.com/wso2/product-ei/issues/5472

