### PR TITLE
Added a new method to the TransportSender interface to let the Application layer notify the transport layer about errors

### DIFF
--- a/modules/kernel/src/org/apache/axis2/transport/TransportSender.java
+++ b/modules/kernel/src/org/apache/axis2/transport/TransportSender.java
@@ -62,4 +62,13 @@ public interface TransportSender extends Handler {
             throws AxisFault;
 
     public void stop();
+
+    /**
+     * This method is used by the Application layer to notify the transport layer about errors.
+     *
+     * @param msgContext The outgoing message context sent via the sender
+     */
+    default void onAppError(MessageContext msgContext) {
+        // Do nothing
+    }
 }


### PR DESCRIPTION
## Purpose
Added a new method to the TransportSender interface to let the Application layer notify the transport layer about errors. This method will be overridden by specific transports to handle the error scenarios.

Fixes: https://github.com/wso2/api-manager/issues/1746