### PR TITLE
Enable setCharacterEncoding property in MultipartFormDataFormatter

### DIFF
--- a/modules/kernel/src/org/apache/axis2/transport/http/MultipartFormDataFormatter.java
+++ b/modules/kernel/src/org/apache/axis2/transport/http/MultipartFormDataFormatter.java
@@ -213,7 +213,7 @@ public class MultipartFormDataFormatter implements MessageFormatter {
         String encoding = format.getCharSetEncoding();
         String setEncoding = (String) messageContext.getProperty(Constants.Configuration
                 .SET_CONTENT_TYPE_CHARACTER_ENCODING);
-        if (encoding != null && !"false".equalsIgnoreCase(setEncoding)) {
+        if (encoding != null && "true".equalsIgnoreCase(setEncoding)) {
             contentType += "; charset=" + encoding;
         }
         contentType = contentType + "; " + "boundary=" + format.getMimeBoundary();


### PR DESCRIPTION
This PR would enable setCharacterEncoding property in MultipartFormDataFormatter
When the setCharacterEncoding property is not set, character encoding would not be added.

Ported from: https://github.com/wso2-support/wso2-axis2/pull/386
Resolves: https://github.com/wso2/api-manager/issues/1908