### PR TITLE
Adds extractServicePath method to get Absolute url

### DIFF
--- a/modules/kernel/src/org/apache/axis2/description/OutInAxisOperation.java
+++ b/modules/kernel/src/org/apache/axis2/description/OutInAxisOperation.java
@@ -45,7 +45,6 @@ import org.apache.axis2.wsdl.WSDLConstants;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.commons.httpclient.HttpStatus;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/modules/kernel/src/org/apache/axis2/description/OutInAxisOperation.java
+++ b/modules/kernel/src/org/apache/axis2/description/OutInAxisOperation.java
@@ -45,6 +45,7 @@ import org.apache.axis2.wsdl.WSDLConstants;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.commons.httpclient.HttpStatus;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/modules/kernel/src/org/apache/axis2/util/Utils.java
+++ b/modules/kernel/src/org/apache/axis2/util/Utils.java
@@ -276,7 +276,7 @@ public class Utils {
             return null;
         }
 
-        if (servicePathValidation && !path.startsWith(servicePath)) {
+        if (servicePathValidation && !extractServicePath(path).startsWith(servicePath)) {
             // Cannot add logs here since this method is called from several axis2 phases
             // and inbound endpoints. If we add logs here, it will be printed for valid cases as well.
             return null;
@@ -305,6 +305,30 @@ public class Utils {
             }
         }
         return serviceOpPart;
+    }
+
+    /**
+     +     * Gives the service part from the incoming EPR
+     +     * @param path - incoming EPR
+     +     * @return - service part
+     +     */
+    private static String extractServicePath(String path) {
+
+        if ((path.startsWith("https://") || path.startsWith("http://"))
+                && path.chars().filter(ch -> ch == '/').count() >= 3) {
+            // loop through the chars of path, find index of 3rd '/' and return the substring
+            // ex: http://localhost:8290/services/bla -> /services/bla
+            int index = 0;
+            int count = 0;
+            while (count < 3) {
+                index = path.indexOf('/', index + 1);
+                count++;
+            }
+            return path.substring(index);
+        } else if (path.startsWith("local://")) {
+            return path.substring("local:/".length());
+        }
+        return path;
     }
 
     /**


### PR DESCRIPTION
## Overview
Due to the msgcontext having the fully qualified variable instead of the absolute url, it restricted all the service calls for the carbon console. This PR fixes it by extracting the absolute url from the fully qualified url.

Resolves : https://github.com/wso2/api-manager/issues/2313