### PR TITLE
Allow headers to be preserved in blocking transport

### DIFF
--- a/modules/transport/http/src/org/apache/axis2/transport/http/AbstractHTTPSender.java
+++ b/modules/transport/http/src/org/apache/axis2/transport/http/AbstractHTTPSender.java
@@ -774,6 +774,10 @@ public abstract class AbstractHTTPSender {
                     }
 
                     if (!headerAdded) {
+                        if (isPreserveHttpHeader(HTTPConstants.HEADER_USER_AGENT) && HTTPConstants.HEADER_USER_AGENT
+                                .equalsIgnoreCase(((Map.Entry) headerEntry).getKey().toString())) {
+                            isCustomUserAgentSet = true;
+                        }
                         if (((Map.Entry) headerEntry).getValue() != null) {
                             method.addRequestHeader(((Map.Entry) headerEntry).getKey().toString(),
                                     ((Map.Entry) headerEntry).getValue().toString());


### PR DESCRIPTION

## Purpose
Add capability to preserve given headers in blocking transport. Also specially treat User-Agent when it's preserved.

Fixes: https://github.com/wso2/product-micro-integrator/issues/3888
