### PR TITLE
Move deployable sorting logic into deployer

### DIFF
--- a/modules/kernel/src/org/apache/axis2/deployment/Deployer.java
+++ b/modules/kernel/src/org/apache/axis2/deployment/Deployer.java
@@ -22,6 +22,12 @@ package org.apache.axis2.deployment;
 import org.apache.axis2.context.ConfigurationContext;
 import org.apache.axis2.deployment.repository.util.DeploymentFileData;
 
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
 /**
  * This interface is used to provide the custom deployment mechanism , where you
  * can write your own Deployer to process a particular type and make that to
@@ -66,4 +72,28 @@ public interface Deployer {
      * @throws DeploymentException If an error occurs during cleanup
      */
     void cleanup() throws DeploymentException;
+
+    /**
+     * Sorts a sublist of the given list of DeploymentFileData objects by file name in ascending order.
+     *
+     * @param filesToDeploy the list of DeploymentFileData
+     * @param startIndex the start index (inclusive) of the sublist to sort
+     * @param toIndex the end index (exclusive) of the sublist to sort
+     */
+    default void sort(List<DeploymentFileData> filesToDeploy, int startIndex, int toIndex) {
+        if (filesToDeploy == null || filesToDeploy.isEmpty()) {
+            return;
+        }
+        if (startIndex < 0 || toIndex > filesToDeploy.size() || startIndex >= toIndex) {
+            return;
+        }
+
+        List<DeploymentFileData> subList = filesToDeploy.subList(startIndex, toIndex);
+        Collections.sort(subList, new Comparator<DeploymentFileData>() {
+            @Override
+            public int compare(DeploymentFileData d1, DeploymentFileData d2) {
+                return d1.getFile().getName().compareTo(d2.getFile().getName());
+            }
+        });
+    }
 }

--- a/modules/kernel/src/org/apache/axis2/deployment/DeploymentEngine.java
+++ b/modules/kernel/src/org/apache/axis2/deployment/DeploymentEngine.java
@@ -843,12 +843,18 @@ public abstract class DeploymentEngine implements DeploymentConstants {
                     break;
                 }
             }
-            //sort artifacts belonging to each category, within the list itself.
-            Collections.sort(wsToDeploy.subList(startIndex, artifactsCount), new Comparator<DeploymentFileData>() {
-                public int compare(DeploymentFileData deploymentFileData1, DeploymentFileData deploymentFileData2) {
-                    return deploymentFileData1.getFile().getName().compareTo(deploymentFileData2.getFile().getName());
-                }
-            });
+            //sort the artifacts in the category
+            Deployer tempDeployer = tempDeployableArtifact.getDeployer();
+            if (tempDeployer != null) {
+                tempDeployer.sort(wsToDeploy, startIndex, artifactsCount);
+            } else {
+                //sort artifacts belonging to each category, within the list itself.
+                Collections.sort(wsToDeploy.subList(startIndex, artifactsCount), new Comparator<DeploymentFileData>() {
+                    public int compare(DeploymentFileData deploymentFileData1, DeploymentFileData deploymentFileData2) {
+                        return deploymentFileData1.getFile().getName().compareTo(deploymentFileData2.getFile().getName());
+                    }
+                });
+            }
         }
     }
 

--- a/modules/kernel/test/org/apache/axis2/deployment/CustomDeployerTest.java
+++ b/modules/kernel/test/org/apache/axis2/deployment/CustomDeployerTest.java
@@ -23,7 +23,12 @@ import junit.framework.TestCase;
 import org.apache.axis2.AbstractTestCase;
 import org.apache.axis2.context.ConfigurationContextFactory;
 import org.apache.axis2.deployment.deployers.CustomDeployer;
+import org.apache.axis2.deployment.repository.util.DeploymentFileData;
 import org.apache.axis2.engine.AxisConfiguration;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 public class CustomDeployerTest extends TestCase {
     public void testCustomDeployer() throws Exception {
@@ -43,5 +48,113 @@ public class CustomDeployerTest extends TestCase {
         assertEquals("Parameter not set correctly",
                      CustomDeployer.PARAM_VAL,
                      axisConfig.getParameterValue(CustomDeployer.PARAM_NAME));
+    }
+
+    public void testSortCompleteList() {
+        Deployer deployer = new CustomDeployer();
+        List<DeploymentFileData> files = new ArrayList<>();
+        files.add(new DeploymentFileData(new File("zeta.svc"), null));
+        files.add(new DeploymentFileData(new File("alpha.svc"), null));
+        files.add(new DeploymentFileData(new File("beta.svc"), null));
+
+        deployer.sort(files, 0, files.size());
+
+        assertEquals("alpha.svc", files.get(0).getFile().getName());
+        assertEquals("beta.svc", files.get(1).getFile().getName());
+        assertEquals("zeta.svc", files.get(2).getFile().getName());
+    }
+
+    public void testSortEmptyList() {
+        Deployer deployer = new CustomDeployer();
+        List<DeploymentFileData> files = new ArrayList<>();
+        deployer.sort(files, 0, files.size());
+        assertTrue(files.isEmpty());
+    }
+
+    public void testSortSingleElement() {
+        Deployer deployer = new CustomDeployer();
+        List<DeploymentFileData> files = new ArrayList<>();
+        files.add(new DeploymentFileData(new File("single.svc"), null));
+        deployer.sort(files, 0, files.size());
+        assertEquals("single.svc", files.get(0).getFile().getName());
+    }
+
+    public void testSortAlreadySorted() {
+        Deployer deployer = new CustomDeployer();
+        List<DeploymentFileData> files = new ArrayList<>();
+        files.add(new DeploymentFileData(new File("alpha.svc"), null));
+        files.add(new DeploymentFileData(new File("beta.svc"), null));
+        files.add(new DeploymentFileData(new File("zeta.svc"), null));
+        deployer.sort(files, 0, files.size());
+        assertEquals("alpha.svc", files.get(0).getFile().getName());
+        assertEquals("beta.svc", files.get(1).getFile().getName());
+        assertEquals("zeta.svc", files.get(2).getFile().getName());
+    }
+
+    public void testSortReverseOrder() {
+        Deployer deployer = new CustomDeployer();
+        List<DeploymentFileData> files = new ArrayList<>();
+        files.add(new DeploymentFileData(new File("zeta.svc"), null));
+        files.add(new DeploymentFileData(new File("beta.svc"), null));
+        files.add(new DeploymentFileData(new File("alpha.svc"), null));
+        deployer.sort(files, 0, files.size());
+        assertEquals("alpha.svc", files.get(0).getFile().getName());
+        assertEquals("beta.svc", files.get(1).getFile().getName());
+        assertEquals("zeta.svc", files.get(2).getFile().getName());
+    }
+
+    public void testSortMiddleSublist() {
+        Deployer deployer = new CustomDeployer();
+        List<DeploymentFileData> files = new ArrayList<>();
+        files.add(new DeploymentFileData(new File("gamma.svc"), null));
+        files.add(new DeploymentFileData(new File("zeta.svc"), null));
+        files.add(new DeploymentFileData(new File("alpha.svc"), null));
+        files.add(new DeploymentFileData(new File("beta.svc"), null));
+        files.add(new DeploymentFileData(new File("omega.svc"), null));
+
+        // Sort only the middle three elements (indices 1 to 3)
+        deployer.sort(files, 1, 4);
+
+        assertEquals("gamma.svc", files.get(0).getFile().getName());
+        assertEquals("alpha.svc", files.get(1).getFile().getName());
+        assertEquals("beta.svc", files.get(2).getFile().getName());
+        assertEquals("zeta.svc", files.get(3).getFile().getName());
+        assertEquals("omega.svc", files.get(4).getFile().getName());
+    }
+
+    public void testSortSublistAtStart() {
+        Deployer deployer = new CustomDeployer();
+        List<DeploymentFileData> files = new ArrayList<>();
+        files.add(new DeploymentFileData(new File("zeta.svc"), null));
+        files.add(new DeploymentFileData(new File("alpha.svc"), null));
+        files.add(new DeploymentFileData(new File("beta.svc"), null));
+        files.add(new DeploymentFileData(new File("omega.svc"), null));
+
+        // Sort only the first three elements (indices 0 to 2)
+        deployer.sort(files, 0, 3);
+
+        assertEquals("alpha.svc", files.get(0).getFile().getName());
+        assertEquals("beta.svc", files.get(1).getFile().getName());
+        assertEquals("zeta.svc", files.get(2).getFile().getName());
+        assertEquals("omega.svc", files.get(3).getFile().getName());
+    }
+
+    public void testSortSublistAtEnd() {
+        Deployer deployer = new CustomDeployer();
+        List<DeploymentFileData> files = new ArrayList<>();
+        files.add(new DeploymentFileData(new File("gamma.svc"), null));
+        files.add(new DeploymentFileData(new File("omega.svc"), null));
+        files.add(new DeploymentFileData(new File("zeta.svc"), null));
+        files.add(new DeploymentFileData(new File("alpha.svc"), null));
+        files.add(new DeploymentFileData(new File("beta.svc"), null));
+
+        // Sort only the last three elements (indices 2 to 4)
+        deployer.sort(files, 2, 5);
+
+        assertEquals("gamma.svc", files.get(0).getFile().getName());
+        assertEquals("omega.svc", files.get(1).getFile().getName());
+        assertEquals("alpha.svc", files.get(2).getFile().getName());
+        assertEquals("beta.svc", files.get(3).getFile().getName());
+        assertEquals("zeta.svc", files.get(4).getFile().getName());
     }
 }


### PR DESCRIPTION
## Purpose
This PR introduces a change to support custom sorting of `.car` files during deployment based on their dependencies. 

To enable this, the responsibility of sorting deployables is moved to the deployer itself. This allows each deployer to define its own sorting mechanism.