### PR TITLE
Improve Blocking Mode Proxy Service Calls

### DIFF
--- a/modules/integration/test/org/apache/axis2/transport/http/NonProxyHostTest.java
+++ b/modules/integration/test/org/apache/axis2/transport/http/NonProxyHostTest.java
@@ -25,9 +25,9 @@ import org.apache.axis2.transport.http.util.HTTPProxyConfigurationUtil;
 public class NonProxyHostTest extends TestCase {
     public void testForAxis2_3453() {
         String nonProxyHosts = "sealbook.ncl.ac.uk|*.sealbook.ncl.ac.uk|eskdale.ncl.ac.uk|*.eskdale.ncl.ac.uk|giga25.ncl.ac.uk|*.giga25.ncl.ac.uk";
-        assertTrue(HTTPProxyConfigurationUtil.isHostInNonProxyList("sealbook.ncl.ac.uk", nonProxyHosts));
-        assertFalse(HTTPProxyConfigurationUtil.isHostInNonProxyList("xsealbook.ncl.ac.uk", nonProxyHosts));
-        assertTrue(HTTPProxyConfigurationUtil.isHostInNonProxyList("local","local|*.local|169.254/16|*.169.254/16"));
-        assertFalse(HTTPProxyConfigurationUtil.isHostInNonProxyList("localhost","local|*.local|169.254/16|*.169.254/16"));
+        assertTrue(HTTPProxyConfigurationUtil.isHostInPatternList("sealbook.ncl.ac.uk", nonProxyHosts));
+        assertFalse(HTTPProxyConfigurationUtil.isHostInPatternList("xsealbook.ncl.ac.uk", nonProxyHosts));
+        assertTrue(HTTPProxyConfigurationUtil.isHostInPatternList("local","local|*.local|169.254/16|*.169.254/16"));
+        assertFalse(HTTPProxyConfigurationUtil.isHostInPatternList("localhost","local|*.local|169.254/16|*.169.254/16"));
     }
 }

--- a/modules/transport/http/src/org/apache/axis2/transport/http/AbstractHTTPSender.java
+++ b/modules/transport/http/src/org/apache/axis2/transport/http/AbstractHTTPSender.java
@@ -348,7 +348,7 @@ public abstract class AbstractHTTPSender {
             if(log.isDebugEnabled()){
                 log.debug("Configuring HTTP proxy.");
             }
-            HTTPProxyConfigurationUtil.configure(msgCtx, client, config);
+            HTTPProxyConfigurationUtil.configure(msgCtx, client, config, targetURL);
         }
 
         return config;

--- a/modules/transport/http/src/org/apache/axis2/transport/http/util/HTTPProxyConfigurationUtil.java
+++ b/modules/transport/http/src/org/apache/axis2/transport/http/util/HTTPProxyConfigurationUtil.java
@@ -167,6 +167,16 @@ public class HTTPProxyConfigurationUtil {
         config.setProxy(proxyHost, proxyPort);
     }
 
+    /**
+     * Configure HTTP Proxy settings of commons-httpclient HostConfiguration. Proxy settings can be get from
+     * axis2.xml, Java proxy settings or can be override through property in message context.
+     *
+     * @param messageContext message context
+     * @param httpClient     commons-httpclient instance
+     * @param config         commons-httpclient HostConfiguration
+     * @param targetURL      URL of the endpoint which we are sending the request
+     * @throws AxisFault if Proxy settings are invalid
+     */
     public static void configure(MessageContext messageContext,
                                  HttpClient httpClient,
                                  HostConfiguration config, URL targetURL) throws AxisFault {


### PR DESCRIPTION
### Purpose
- The following improvements were done with regard to blocking mode proxy service calls
  - Read the following proxy related configurations related to blocking mode from deployment.toml file
 ```
[transport.blocking_https]
sender.parameters.'http.proxyHost' = "<OUT_PROXY_HOST>"
sender.parameters.'http.proxyPort' = "<OUT_PROXY_PORT>"
sender.parameters.'http.nonProxyHosts' = "<OUT_PROXY_NON_HOSTS>"
```
  - Introduced a new parameter called 'http.targetHosts' to define the list of hosts to which the HTTP traffic should be sent through the proxy. The idea of introducing this parameter is to handle scenarios where less backend traffic is routed via a proxy. In such a scenario, rather than defining a comprehensive list of direct call URLs under http.nonProxyHosts, this parameter allows to define only the list of hosts to which the HTTP traffic should be sent through the proxy.
```
[transport.blocking_https]
sender.parameters.'http.targeHosts' = "<OUT_PROXY_TARGET_HOSTS>"
```

- **Related public issue:** https://github.com/wso2/api-manager/issues/3890