### PR TITLE
Preserve the content-transfer-encoding in multipart/form data

### DIFF
--- a/modules/kernel/conf/axis2.xml
+++ b/modules/kernel/conf/axis2.xml
@@ -99,6 +99,9 @@
     <!-- Configuration to disable sending charset parameter in multipart/related Content-Type header -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">true</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">true</parameter>
+
     <!-- Following parameter will suppress generation of SOAP 1.2 bindings in auto-generated WSDL files -->
     <parameter name="disableSOAP12" locked="true">false</parameter>
 

--- a/modules/kernel/src/org/apache/axis2/Constants.java
+++ b/modules/kernel/src/org/apache/axis2/Constants.java
@@ -345,6 +345,11 @@ public class Constants extends org.apache.axis2.namespace.Constants {
     public static final String FAT_CAR_ENABLED = "fatCarEnabled";
     public static final String DESCRIPTOR_XML = "descriptor.xml";
 
+    /**
+     * Reserved attribute name for content-transfer-encoding
+     */
+    public static final String CONTENT_TRANSFER_ENCODING = "content-transfer-encoding";
+
     public static interface Configuration {
         public static final String ENABLE_REST = "enableREST";
         public static final String ENABLE_HTTP_CONTENT_NEGOTIATION = "httpContentNegotiation";

--- a/modules/kernel/src/org/apache/axis2/Constants.java
+++ b/modules/kernel/src/org/apache/axis2/Constants.java
@@ -518,5 +518,14 @@ public class Constants extends org.apache.axis2.namespace.Constants {
          */
         public static final String DISABLE_SENDING_MULTIPART_PART_CHARSET =
                 "disableSendingMultipartPartCharset";
+
+        /**
+         * This parameter preserves the Content-Transfer-Encoding header in individual parts in multipart data.
+         * If this is set to false the Content-Transfer-Encoding header is added to individual parts in multipart data.
+         * If this is set to true the existing Content-Transfer-Encoding header is preserved in individual parts
+         * in multipart data.
+         */
+        public static final String PRESERVE_CONTENT_TRANSFER_ENCODING =
+                "preserveMultipartPartContentTransferEncoding";
     }
 }

--- a/modules/kernel/src/org/apache/axis2/builder/BuilderUtil.java
+++ b/modules/kernel/src/org/apache/axis2/builder/BuilderUtil.java
@@ -101,6 +101,14 @@ public class BuilderUtil {
                                                 MultipleEntryHashMap requestParameterMap,
                                                 SOAPFactory soapFactory) throws AxisFault {
 
+        Parameter preserveMultipartPartContentTransferEncoding = messageContext.getParameter(
+                Constants.Configuration.PRESERVE_CONTENT_TRANSFER_ENCODING);
+        boolean preserveMultipartPartContentTransferEncodingValue = false;
+        if (preserveMultipartPartContentTransferEncoding != null) {
+            preserveMultipartPartContentTransferEncodingValue =
+                    JavaUtils.isTrueExplicitly(preserveMultipartPartContentTransferEncoding.getValue());
+        }
+
         SOAPEnvelope soapEnvelope = soapFactory.getDefaultEnvelope();
         SOAPBody body = soapEnvelope.getBody();
         XmlSchemaElement xmlSchemaElement;
@@ -118,7 +126,8 @@ public class BuilderUtil {
                 // if there is no schema its piece of cake !! add these to the soap body in any order you like.
                 // Note : if there are parameters in the path of the URL, there is no way this can add them
                 // to the message.
-                createSOAPMessageWithoutSchema(soapFactory, bodyFirstChild, requestParameterMap);
+                createSOAPMessageWithoutSchemaWithContentTransferEncoding(soapFactory, bodyFirstChild,
+                        requestParameterMap, preserveMultipartPartContentTransferEncodingValue);
             } else {
 
                 // first get the target namespace from the schema and the wrapping element.
@@ -155,8 +164,9 @@ public class BuilderUtil {
                             
                             if (qName == null && innerElement.getSchemaTypeName()
                                     .equals(org.apache.ws.commons.schema.constants.Constants.XSD_ANYTYPE)) {
-                                createSOAPMessageWithoutSchema(soapFactory, bodyFirstChild,
-                                                               requestParameterMap);
+                                createSOAPMessageWithoutSchemaWithContentTransferEncoding(soapFactory, bodyFirstChild,
+                                        requestParameterMap,
+                                        preserveMultipartPartContentTransferEncodingValue);
                                 break;
                             }
                             long minOccurs = innerElement.getMinOccurs();
@@ -173,7 +183,8 @@ public class BuilderUtil {
                             // FIXME changed
                             while ((value = requestParameterMap.get(name)) != null) {
                                 addRequestParameter(soapFactory,
-                                                    bodyFirstChild, ns, name, value);
+                                        bodyFirstChild, ns, name, value,
+                                        preserveMultipartPartContentTransferEncodingValue);
                                 minOccurs--;
                             }
                             if (minOccurs > 0) {
@@ -202,9 +213,40 @@ public class BuilderUtil {
         return soapEnvelope;
     }
 
+    /**
+     * This method is used to create a SOAP message without schema information and does not add the content
+     * transfer encoding value of the multipart form data parameters to the SOAP message.
+     * @param soapFactory soap factory to create the SOAP message
+     * @param bodyFirstChild first child of the SOAP body to which the parameters will be added as children
+     * @param requestParameterMap request parameter map containing the parameters to be added to the SOAP message.
+     *
+     * @deprecated use {@link #createSOAPMessageWithoutSchemaWithContentTransferEncoding(SOAPFactory, OMElement,
+     * MultipleEntryHashMap, boolean)} instead
+     */
+    @Deprecated
     public static void createSOAPMessageWithoutSchema(SOAPFactory soapFactory,
                                                        OMElement bodyFirstChild,
                                                        MultipleEntryHashMap requestParameterMap) {
+
+        createSOAPMessageWithoutSchemaWithContentTransferEncoding(soapFactory, bodyFirstChild,
+                requestParameterMap, false);
+    }
+
+    /**
+     * This method is used to create a SOAP message without schema information.
+     * Adds the content transfer encoding value of the multipart form data parameters to the SOAP Message if the
+     * preserveMultipartPartContentTransferEncodingValue parameter is set to true.
+     * @param soapFactory soap factory to create the SOAP message
+     * @param bodyFirstChild first child of the SOAP body to which the parameters will be added as children
+     * @param requestParameterMap request parameter map containing the parameters to be added to the SOAP message.
+     * @param preserveMultipartPartContentTransferEncodingValue whether to add the content transfer encoding value
+     *                                                         of the multipart form data parameters to the SOAP message
+     */
+    public static void createSOAPMessageWithoutSchemaWithContentTransferEncoding(
+            SOAPFactory soapFactory,
+            OMElement bodyFirstChild,
+            MultipleEntryHashMap requestParameterMap,
+            boolean preserveMultipartPartContentTransferEncodingValue) {
 
         // first add the parameters in the URL
         if (requestParameterMap != null) {
@@ -212,7 +254,8 @@ public class BuilderUtil {
                 String key = (String) o;
                 Object value;
                 while ((value = requestParameterMap.get(key)) != null) {
-                    addRequestParameter(soapFactory, bodyFirstChild, null, key, value);
+                    addRequestParameter(soapFactory, bodyFirstChild, null, key, value,
+                            preserveMultipartPartContentTransferEncodingValue);
                 }
             }
         }
@@ -222,7 +265,8 @@ public class BuilderUtil {
                                             OMElement bodyFirstChild,
                                             OMNamespace ns,
                                             String key,
-                                            Object parameter) {
+                                            Object parameter,
+                                            boolean preserveMultipartPartContentTransferEncodingValue) {
         if (parameter instanceof DataHandler) {
             DataHandler dataHandler = (DataHandler)parameter;
             OMText dataText = bodyFirstChild.getOMFactory().createOMText(
@@ -237,16 +281,24 @@ public class BuilderUtil {
                 omElement.addAttribute(CONTENT_TYPE, DEFAULT_CONTENT_TYPE, ns);
             }
             omElement.addAttribute("filename", ((DataHandler) parameter).getDataSource().getName(), ns);
+            String partContentTransferEncoding = getContentTransferEncoding(dataSource);
+            if (preserveMultipartPartContentTransferEncodingValue && partContentTransferEncoding != null) {
+                omElement.addAttribute(Constants.CONTENT_TRANSFER_ENCODING, partContentTransferEncoding, ns);
+            }
         } else if (parameter instanceof Map) {
             HashMap textParameterObj = (HashMap) parameter;
             String testVal = (String) textParameterObj.get("value");
             String charsetVal = (String) textParameterObj.get("charset");
             String partContentType = (String) textParameterObj.get("contentType");
+            String partContentTransferEncoding = (String) textParameterObj.get("contentTransferEncoding");
             OMElement omElement = soapFactory.createOMElement(key, ns, bodyFirstChild);
             omElement.setText(testVal);
             omElement.addAttribute("charset", charsetVal, ns);
             if (partContentType != null) {
                 omElement.addAttribute(CONTENT_TYPE, partContentType, ns);
+            }
+            if (preserveMultipartPartContentTransferEncodingValue && partContentTransferEncoding != null) {
+                omElement.addAttribute(Constants.CONTENT_TRANSFER_ENCODING, partContentTransferEncoding, ns);
             }
         } else {
             String textValue = parameter.toString();
@@ -859,5 +911,19 @@ public class BuilderUtil {
             enc2 = enc2.substring(0, enc2.length() - 2);
         }
         return enc1.equals(enc2);
+    }
+
+    /**
+     * Extracts the content transfer encoding from the given DataSource if possible.
+     * This is required to support multipart form data where the content transfer encoding is specified in the headers
+     * of the part.
+     * @param dataSource the DataSource to extract the content transfer encoding from
+     * @return the content transfer encoding if it can be extracted, or null otherwise
+     */
+    private static String getContentTransferEncoding(DataSource dataSource) {
+        if (dataSource instanceof DiskFileDataSource) {
+            return ((DiskFileDataSource) dataSource).getContentTransferEncoding();
+        }
+        return null;
     }
 }

--- a/modules/kernel/src/org/apache/axis2/builder/DiskFileDataSource.java
+++ b/modules/kernel/src/org/apache/axis2/builder/DiskFileDataSource.java
@@ -24,6 +24,7 @@ import java.io.OutputStream;
 
 import javax.activation.DataSource;
 
+import org.apache.axis2.Constants;
 import org.apache.commons.fileupload.disk.DiskFileItem;
 
 public class DiskFileDataSource implements DataSource {
@@ -52,6 +53,17 @@ public class DiskFileDataSource implements DataSource {
 
     public void delete() {
         this.diskFileItem.delete();
+    }
+
+    /**
+     * Get the content transfer encoding of the file item.
+     * @return the content transfer encoding, or <code>null</code> if not specified.
+     */
+    public String getContentTransferEncoding() {
+        if (this.diskFileItem == null || this.diskFileItem.getHeaders() == null) {
+            return null;
+        }
+        return this.diskFileItem.getHeaders().getHeader(Constants.CONTENT_TRANSFER_ENCODING);
     }
 
 }

--- a/modules/kernel/src/org/apache/axis2/builder/MultipartFormDataBuilder.java
+++ b/modules/kernel/src/org/apache/axis2/builder/MultipartFormDataBuilder.java
@@ -160,6 +160,8 @@ public class MultipartFormDataBuilder implements Builder {
         textParameterMap.put("value", textValue);
         textParameterMap.put("charset", encoding);
         textParameterMap.put("contentType", partContentType);
+        String contentTransferEncoding = getContentTransferEncoding(diskFileItem);
+        textParameterMap.put("contentTransferEncoding", contentTransferEncoding);
         return textParameterMap;
     }
 
@@ -170,5 +172,12 @@ public class MultipartFormDataBuilder implements Builder {
         DataHandler dataHandler = new DataHandler(dataSource);
 
         return dataHandler;
+    }
+
+    private String getContentTransferEncoding(DiskFileItem diskFileItem) {
+        if (diskFileItem == null || diskFileItem.getHeaders() == null) {
+            return null;
+        }
+        return diskFileItem.getHeaders().getHeader(Constants.CONTENT_TRANSFER_ENCODING);
     }
 }

--- a/modules/kernel/src/org/apache/axis2/transport/http/MultipartFormDataFormatter.java
+++ b/modules/kernel/src/org/apache/axis2/transport/http/MultipartFormDataFormatter.java
@@ -120,7 +120,7 @@ public class MultipartFormDataFormatter implements MessageFormatter {
      * QName of the reserved XML attribute for content-transfer-encoding
      */
     private static final QName CONTENT_TRANSFER_ENCODING_ATTRIBUTE_QNAME = new QName(
-            "content-transfer-encoding");
+            Constants.CONTENT_TRANSFER_ENCODING);
 
     /**
      * QName of the reserved XML attribute for charset
@@ -320,9 +320,9 @@ public class MultipartFormDataFormatter implements MessageFormatter {
                                 ele.getAttribute(CONTENT_TYPE_ATTRIBUTE_QNAME), ComplexPart.DEFAULT_CONTENT_TYPE));
                     }
                     if (preserveMultipartPartContentTransferEncodingValue) {
-                        ((ComplexPart) part).setContentType(getAttributeValue(
-                                ele.getAttribute(CONTENT_TRANSFER_ENCODING_ATTRIBUTE_QNAME),
-                                ComplexPart.DEFAULT_TRANSFER_ENCODING));
+                        OMAttribute transferEncodingAttr = ele.getAttribute(CONTENT_TRANSFER_ENCODING_ATTRIBUTE_QNAME);
+                        ((ComplexPart) part).setTransferEncoding(
+                                transferEncodingAttr != null ? transferEncodingAttr.getAttributeValue() : null);
                     }
                 } else if (FILE_FIELD_QNAME.equals(ele.getQName())) {
 
@@ -342,9 +342,9 @@ public class MultipartFormDataFormatter implements MessageFormatter {
                                 ele.getAttribute(CONTENT_TYPE_ATTRIBUTE_QNAME), FilePart.DEFAULT_CONTENT_TYPE));
                     }
                     if (preserveMultipartPartContentTransferEncodingValue) {
-                        ((FilePart) part).setContentType(getAttributeValue(
-                                ele.getAttribute(CONTENT_TRANSFER_ENCODING_ATTRIBUTE_QNAME),
-                                FilePart.DEFAULT_TRANSFER_ENCODING));
+                        OMAttribute transferEncodingAttr = ele.getAttribute(CONTENT_TRANSFER_ENCODING_ATTRIBUTE_QNAME);
+                        ((FilePart) part).setTransferEncoding(
+                                transferEncodingAttr != null ? transferEncodingAttr.getAttributeValue() : null);
                     }
                 } else if ((ele.getAttribute(FILENAME_ATTRIBUTE_QNAME) != null)) {
                     String fieldName = getAttributeValue(ele.getAttribute(FILE_FIELD_NAME_ATTRIBUTE_QNAME),
@@ -380,9 +380,9 @@ public class MultipartFormDataFormatter implements MessageFormatter {
                                 ele.getAttribute(CONTENT_TYPE_ATTRIBUTE_QNAME), FilePart.DEFAULT_CONTENT_TYPE));
                     }
                     if (preserveMultipartPartContentTransferEncodingValue) {
-                        ((FilePart) part).setContentType(getAttributeValue(
-                                ele.getAttribute(CONTENT_TRANSFER_ENCODING_ATTRIBUTE_QNAME),
-                                FilePart.DEFAULT_TRANSFER_ENCODING));
+                        OMAttribute transferEncodingAttr = ele.getAttribute(CONTENT_TRANSFER_ENCODING_ATTRIBUTE_QNAME);
+                        ((FilePart) part).setTransferEncoding(
+                                transferEncodingAttr != null ? transferEncodingAttr.getAttributeValue() : null);
                     }
                 } else {
                     // Gets the first child object
@@ -425,9 +425,10 @@ public class MultipartFormDataFormatter implements MessageFormatter {
                                     ele.getAttribute(CONTENT_TYPE_ATTRIBUTE_QNAME), StringPart.DEFAULT_CONTENT_TYPE));
                         }
                         if (preserveMultipartPartContentTransferEncodingValue) {
-                            ((StringPart) part).setContentType(getAttributeValue(
-                                    ele.getAttribute(CONTENT_TRANSFER_ENCODING_ATTRIBUTE_QNAME),
-                                    StringPart.DEFAULT_TRANSFER_ENCODING));
+                            OMAttribute transferEncodingAttr = ele.getAttribute(
+                                    CONTENT_TRANSFER_ENCODING_ATTRIBUTE_QNAME);
+                            ((StringPart) part).setTransferEncoding(
+                                    transferEncodingAttr != null ? transferEncodingAttr.getAttributeValue() : null);
                         }
                     }
                 }

--- a/modules/kernel/src/org/apache/axis2/transport/http/MultipartFormDataFormatter.java
+++ b/modules/kernel/src/org/apache/axis2/transport/http/MultipartFormDataFormatter.java
@@ -117,6 +117,12 @@ public class MultipartFormDataFormatter implements MessageFormatter {
     private static final QName CONTENT_TYPE_ATTRIBUTE_QNAME = new QName("content-type");
 
     /**
+     * QName of the reserved XML attribute for content-transfer-encoding
+     */
+    private static final QName CONTENT_TRANSFER_ENCODING_ATTRIBUTE_QNAME = new QName(
+            "content-transfer-encoding");
+
+    /**
      * QName of the reserved XML attribute for charset
      */
     private static final QName CHARSET_ATTRIBUTE_QNAME = new QName("charset");
@@ -259,6 +265,13 @@ public class MultipartFormDataFormatter implements MessageFormatter {
                 disableSendingMultipartPartCharsetValue =
                         JavaUtils.isTrueExplicitly(disableSendingMultipartPartCharset.getValue());
             }
+            Parameter preserveMultipartPartContentTransferEncoding =
+                    messageContext.getParameter(Constants.Configuration.PRESERVE_CONTENT_TRANSFER_ENCODING);
+            boolean preserveMultipartPartContentTransferEncodingValue = true;
+            if (preserveMultipartPartContentTransferEncoding != null) {
+                preserveMultipartPartContentTransferEncodingValue =
+                        JavaUtils.isTrueExplicitly(preserveMultipartPartContentTransferEncoding.getValue());
+            }
             OMFactory omFactory = null;
             if (soapVersion != null) {
                 if (soapVersion.equals(Constants.SOAP_11)) {
@@ -285,21 +298,31 @@ public class MultipartFormDataFormatter implements MessageFormatter {
                         String charset = BuilderUtil.extractCharSetValue(contentType);
                         if (soapVersion.equals(Constants.SOAP_11)) {
                             part = new ComplexPart(ele.getQName().getLocalPart(), omElement.toString(),
-                                    disableSendingMultipartPartCharsetValue, charset, "text/xml");
+                                    disableSendingMultipartPartCharsetValue,
+                                    preserveMultipartPartContentTransferEncodingValue, charset, "text/xml");
                         } else if (soapVersion.equals(Constants.SOAP_12)) {
                             part = new ComplexPart(ele.getQName().getLocalPart(), omElement.toString(),
-                                    disableSendingMultipartPartCharsetValue, charset, "application/soap+xml");
+                                    disableSendingMultipartPartCharsetValue,
+                                    preserveMultipartPartContentTransferEncodingValue, charset,
+                                    "application/soap+xml");
                         } else {
                             part = new ComplexPart(ele.getQName().getLocalPart(), omElement.toString(),
-                                    disableSendingMultipartPartCharsetValue);
+                                    disableSendingMultipartPartCharsetValue,
+                                    preserveMultipartPartContentTransferEncodingValue);
                         }
                     } else {
                         part = new ComplexPart(ele.getQName().getLocalPart(), omElement.toString(),
-                                disableSendingMultipartPartCharsetValue);
+                                disableSendingMultipartPartCharsetValue,
+                                preserveMultipartPartContentTransferEncodingValue);
                     }
                     if (disableSendingMultipartPartCharsetValue) {
                         ((ComplexPart) part).setContentType(getAttributeValue(
                                 ele.getAttribute(CONTENT_TYPE_ATTRIBUTE_QNAME), ComplexPart.DEFAULT_CONTENT_TYPE));
+                    }
+                    if (preserveMultipartPartContentTransferEncodingValue) {
+                        ((ComplexPart) part).setContentType(getAttributeValue(
+                                ele.getAttribute(CONTENT_TRANSFER_ENCODING_ATTRIBUTE_QNAME),
+                                ComplexPart.DEFAULT_TRANSFER_ENCODING));
                     }
                 } else if (FILE_FIELD_QNAME.equals(ele.getQName())) {
 
@@ -312,10 +335,16 @@ public class MultipartFormDataFormatter implements MessageFormatter {
 
                     part = new FilePart(fieldName,
                             new ByteArrayPartSource(filename, Base64.decodeBase64(ele.getText().getBytes())),
-                            contentType, disableSendingMultipartPartCharsetValue, charset);
+                            contentType, disableSendingMultipartPartCharsetValue,
+                            preserveMultipartPartContentTransferEncodingValue, charset);
                     if (disableSendingMultipartPartCharsetValue) {
                         ((FilePart) part).setContentType(getAttributeValue(
                                 ele.getAttribute(CONTENT_TYPE_ATTRIBUTE_QNAME), FilePart.DEFAULT_CONTENT_TYPE));
+                    }
+                    if (preserveMultipartPartContentTransferEncodingValue) {
+                        ((FilePart) part).setContentType(getAttributeValue(
+                                ele.getAttribute(CONTENT_TRANSFER_ENCODING_ATTRIBUTE_QNAME),
+                                FilePart.DEFAULT_TRANSFER_ENCODING));
                     }
                 } else if ((ele.getAttribute(FILENAME_ATTRIBUTE_QNAME) != null)) {
                     String fieldName = getAttributeValue(ele.getAttribute(FILE_FIELD_NAME_ATTRIBUTE_QNAME),
@@ -339,14 +368,21 @@ public class MultipartFormDataFormatter implements MessageFormatter {
                     if (decodeMultipartData != null && decodeMultipartData) {
                         part = new FilePart(fieldName,
                                 new ByteArrayPartSource(filename, Base64.decodeBase64(ele.getText().getBytes())),
-                                contentType, disableSendingMultipartPartCharsetValue, charset);
+                                contentType, disableSendingMultipartPartCharsetValue,
+                                preserveMultipartPartContentTransferEncodingValue, charset);
                     } else {
                         part = new FilePart(fieldName, new ByteArrayPartSource(filename, ele.getText().getBytes()),
-                                contentType, disableSendingMultipartPartCharsetValue, charset);
+                                contentType, disableSendingMultipartPartCharsetValue,
+                                preserveMultipartPartContentTransferEncodingValue, charset);
                     }
                     if (disableSendingMultipartPartCharsetValue) {
                         ((FilePart) part).setContentType(getAttributeValue(
                                 ele.getAttribute(CONTENT_TYPE_ATTRIBUTE_QNAME), FilePart.DEFAULT_CONTENT_TYPE));
+                    }
+                    if (preserveMultipartPartContentTransferEncodingValue) {
+                        ((FilePart) part).setContentType(getAttributeValue(
+                                ele.getAttribute(CONTENT_TRANSFER_ENCODING_ATTRIBUTE_QNAME),
+                                FilePart.DEFAULT_TRANSFER_ENCODING));
                     }
                 } else {
                     // Gets the first child object
@@ -367,7 +403,8 @@ public class MultipartFormDataFormatter implements MessageFormatter {
                                 // Creates the FilePart
                                 part = new FilePart(ele.getQName().getLocalPart(),
                                         new ByteArrayPartSource(fileName, ele.getText().getBytes()), contentType,
-                                        disableSendingMultipartPartCharsetValue, null);
+                                        disableSendingMultipartPartCharsetValue,
+                                        preserveMultipartPartContentTransferEncodingValue, null);
                             }
                         }
                     }
@@ -376,14 +413,21 @@ public class MultipartFormDataFormatter implements MessageFormatter {
                         if (ele.getQName().getPrefix() != null && !ele.getQName().getPrefix().isEmpty()) {
                             part = new StringPart(ele.getQName().getPrefix() + ":" +
                                     ele.getQName().getLocalPart(),
-                                    ele.getText(), disableSendingMultipartPartCharsetValue, charset);
+                                    ele.getText(), disableSendingMultipartPartCharsetValue,
+                                    preserveMultipartPartContentTransferEncodingValue, charset);
                         } else {
                             part = new StringPart(ele.getQName().getLocalPart(), ele.getText(),
-                                    disableSendingMultipartPartCharsetValue, charset);
+                                    disableSendingMultipartPartCharsetValue,
+                                    preserveMultipartPartContentTransferEncodingValue, charset);
                         }
                         if (disableSendingMultipartPartCharsetValue) {
                             ((StringPart) part).setContentType(getAttributeValue(
                                     ele.getAttribute(CONTENT_TYPE_ATTRIBUTE_QNAME), StringPart.DEFAULT_CONTENT_TYPE));
+                        }
+                        if (preserveMultipartPartContentTransferEncodingValue) {
+                            ((StringPart) part).setContentType(getAttributeValue(
+                                    ele.getAttribute(CONTENT_TRANSFER_ENCODING_ATTRIBUTE_QNAME),
+                                    StringPart.DEFAULT_TRANSFER_ENCODING));
                         }
                     }
                 }

--- a/modules/kernel/src/org/apache/axis2/transport/http/util/ComplexPart.java
+++ b/modules/kernel/src/org/apache/axis2/transport/http/util/ComplexPart.java
@@ -139,6 +139,44 @@ public class ComplexPart extends PartBase {
     /**
      * Constructor.
      *
+     * @param name                                         the name of the part
+     * @param value                                        the string to post
+     * @param disableSendingMultipartPartCharset           whether to send the charset in the Content-Type header
+     * @param preserveMultipartPartContentTransferEncoding whether to preserve the Content-Transfer-Encoding header
+     * @param charset                                      the charset to be used to encode the string,
+     *                                                     if <code>null</code> the {@link #DEFAULT_CHARSET default}
+     *                                                     is used
+     * @param contentType                                  the content type of the part
+     */
+    public ComplexPart(String name, String value, boolean disableSendingMultipartPartCharset,
+                       boolean preserveMultipartPartContentTransferEncoding, String charset, String contentType) {
+        this(name, value, charset, contentType);
+        super.disableSendingMultipartPartCharset = disableSendingMultipartPartCharset;
+        super.preserveMultipartPartContentTransferEncoding = preserveMultipartPartContentTransferEncoding;
+    }
+
+
+    /**
+     * Constructor.
+     *
+     * @param name                                         the name of the part
+     * @param value                                        the string to post
+     * @param disableSendingMultipartPartCharset           whether to send the charset in the Content-Type header
+     * @param preserveMultipartPartContentTransferEncoding whether to preserve the Content-Transfer-Encoding header
+     * @param charset                                      the charset to be used to encode the string,
+     *                                                     if <code>null</code> the {@link #DEFAULT_CHARSET default}
+     *                                                     is used
+     */
+    public ComplexPart(String name, String value, boolean disableSendingMultipartPartCharset,
+                       boolean preserveMultipartPartContentTransferEncoding, String charset) {
+        this(name, value, charset);
+        super.disableSendingMultipartPartCharset = disableSendingMultipartPartCharset;
+        super.preserveMultipartPartContentTransferEncoding = preserveMultipartPartContentTransferEncoding;
+    }
+
+    /**
+     * Constructor.
+     *
      * @param name  The name of the part
      * @param value the string to post
      */
@@ -155,6 +193,20 @@ public class ComplexPart extends PartBase {
      */
     public ComplexPart(String name, String value, boolean disableSendingMultipartPartCharset) {
         this(name, value, disableSendingMultipartPartCharset, null);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param name                                         the name of the part
+     * @param value                                        the string to post
+     * @param disableSendingMultipartPartCharset           whether to send the charset in the Content-Type header
+     * @param preserveMultipartPartContentTransferEncoding whether to preserve the Content-Transfer-Encoding header
+     */
+    public ComplexPart(String name, String value, boolean disableSendingMultipartPartCharset,
+                       boolean preserveMultipartPartContentTransferEncoding) {
+        this(name, value, disableSendingMultipartPartCharset, preserveMultipartPartContentTransferEncoding,
+                null);
     }
 
     /**

--- a/modules/parent/pom.xml
+++ b/modules/parent/pom.xml
@@ -75,7 +75,7 @@
         <bsf.version>2.4.0</bsf.version>
         <commons.codec.version>1.3</commons.codec.version>
         <commons.fileupload.version>1.6.0.wso2v1</commons.fileupload.version>
-        <commons.httpclient.version>3.1.0-wso2v7</commons.httpclient.version>
+        <commons.httpclient.version>3.1.0-wso2v8</commons.httpclient.version>
         <commons.io.version>2.21.0</commons.io.version>
         <commons.logging.version>1.1.1</commons.logging.version>
         <fi.version>1.2.7</fi.version>

--- a/modules/parent/pom.xml
+++ b/modules/parent/pom.xml
@@ -75,7 +75,7 @@
         <bsf.version>2.4.0</bsf.version>
         <commons.codec.version>1.3</commons.codec.version>
         <commons.fileupload.version>1.6.0.wso2v1</commons.fileupload.version>
-        <commons.httpclient.version>3.1.0-wso2v8</commons.httpclient.version>
+        <commons.httpclient.version>3.1.0-wso2v9</commons.httpclient.version>
         <commons.io.version>2.21.0</commons.io.version>
         <commons.logging.version>1.1.1</commons.logging.version>
         <fi.version>1.2.7</fi.version>


### PR DESCRIPTION
### Description

Previously if a multipart content was sent, we added the part content-transfer-encoding header. This PR introduces an axis2 configuration to avoid that.

```
<!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
 <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
```

In the deployment.toml
```
[message_formatter.options]
preserveMultipartPartContentTransferEncoding = true
```

If you want the Content-Transfer-Encoding to be added,
```
[message_formatter.options]
preserveMultipartPartContentTransferEncoding = false
```

Related to - https://github.com/wso2/api-manager/issues/4730
Related PR - https://github.com/wso2/wso2-commons-httpclient/pull/37