### PR TITLE
Update HTTP client caching mechanism to use transport-specific keys

### DIFF
--- a/modules/kernel/src/org/apache/axis2/transport/http/HTTPConstants.java
+++ b/modules/kernel/src/org/apache/axis2/transport/http/HTTPConstants.java
@@ -442,7 +442,7 @@ public class HTTPConstants {
     /**
      * Field CACHED_HTTP_CLIENT
      */
-    public static final String CACHED_HTTP_CLIENT = "CACHED_HTTP_CLIENT";
+    public static final String CACHED_HTTP_CLIENT = "CACHED_HTTP_CLIENT_";
 
     /**
      * The name of the property that sets a HTTP state to be cached. 

--- a/modules/transport/http/src/org/apache/axis2/transport/http/AbstractHTTPSender.java
+++ b/modules/transport/http/src/org/apache/axis2/transport/http/AbstractHTTPSender.java
@@ -612,11 +612,18 @@ public abstract class AbstractHTTPSender {
     protected HttpClient getHttpClient(MessageContext msgContext) {
         ConfigurationContext configContext = msgContext.getConfigurationContext();
 
-        HttpClient httpClient = (HttpClient) msgContext.getProperty(
-                HTTPConstants.CACHED_HTTP_CLIENT);
+        TransportOutDescription transportOut = msgContext.getTransportOut();
+        // To preserve previous functionality use 'https' as the default transport name if transportOut is null
+        String transportName = "https";
+        if (transportOut != null && transportOut.getName() != null) {
+            transportName = transportOut.getName();
+        }
+        String cacheKey = HTTPConstants.CACHED_HTTP_CLIENT + transportName;
+
+        HttpClient httpClient = (HttpClient) msgContext.getProperty(cacheKey);
 
         if (httpClient == null) {
-            httpClient = (HttpClient) configContext.getProperty(HTTPConstants.CACHED_HTTP_CLIENT);
+            httpClient = (HttpClient) configContext.getProperty(cacheKey);
         }
 
         if (httpClient != null) {
@@ -626,11 +633,10 @@ public abstract class AbstractHTTPSender {
         }
 
         synchronized (this) {
-            httpClient = (HttpClient) msgContext.getProperty(HTTPConstants.CACHED_HTTP_CLIENT);
+            httpClient = (HttpClient) msgContext.getProperty(cacheKey);
 
             if (httpClient == null) {
-                httpClient = (HttpClient) configContext.getProperty(
-                        HTTPConstants.CACHED_HTTP_CLIENT);
+                httpClient = (HttpClient) configContext.getProperty(cacheKey);
             }
 
             if (httpClient != null) {

--- a/modules/transport/http/src/org/apache/axis2/transport/http/CommonsHTTPTransportSender.java
+++ b/modules/transport/http/src/org/apache/axis2/transport/http/CommonsHTTPTransportSender.java
@@ -188,9 +188,9 @@ public class CommonsHTTPTransportSender extends AbstractHandler implements
             }
 
             HttpClient httpClient = new HttpClient(connectionManager);
-
+            String cacheKey = HTTPConstants.CACHED_HTTP_CLIENT + transportOut.getName();
             confContext.setProperty(HTTPConstants.REUSE_HTTP_CLIENT, "true");
-            confContext.setProperty(HTTPConstants.CACHED_HTTP_CLIENT, httpClient);
+            confContext.setProperty(cacheKey, httpClient);
         }
     }
 


### PR DESCRIPTION
This pull request updates how HTTP client instances are cached and retrieved in the Axis2 HTTP transport layer to support transport-specific caching. Instead of using a single shared cache key, the cache key now includes the transport name, allowing for separate HTTP client instances per transport. This prevents potential issues with sharing the same HTTP client across different transports.

fixes - https://github.com/wso2/product-integrator-mi/issues/4933