### PR TITLE
Update HTTP client caching mechanism to use transport-specific keys and Add support to set ConnectionIdleTimeout

### DIFF
--- a/modules/kernel/src/org/apache/axis2/transport/http/HTTPConstants.java
+++ b/modules/kernel/src/org/apache/axis2/transport/http/HTTPConstants.java
@@ -388,6 +388,11 @@ public class HTTPConstants {
     public static final String SO_TIMEOUT = "SO_TIMEOUT";
 
     /**
+     * Field CONNECTION_IDLE_TIMEOUT
+     */
+    public static final String CONNECTION_IDLE_TIMEOUT = "CONNECTION_IDLE_TIMEOUT";
+
+    /**
      * Field NO_KEEPALIVE
      */
     public static final String NO_KEEPALIVE = "NO_KEEPALIVE";
@@ -428,6 +433,13 @@ public class HTTPConstants {
      * Field DEFAULT_SO_TIMEOUT
      */
     public static final int DEFAULT_SO_TIMEOUT = 60000;
+
+    /**
+     * Field DEFAULT_CONNECTION_IDLE_TIMEOUT
+     * Setting this to 0 because in commons-httpclient if idle time out is 0 it'll fallback to previous behavior
+     */
+    public static final int DEFAULT_CONNECTION_IDLE_TIMEOUT = 0;
+
 
     /**
      * Field DEFAULT_CONNECTION_TIMEOUT

--- a/modules/transport/http/pom.xml
+++ b/modules/transport/http/pom.xml
@@ -94,6 +94,23 @@
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-kernel</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-httpclient</groupId>
+                    <artifactId>commons-httpclient</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.commons-httpclient</groupId>
+            <artifactId>commons-httpclient</artifactId>
+            <version>3.1.0-wso2v6.17</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-httpclient</groupId>
+                    <artifactId>commons-httpclient</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/modules/transport/http/src/org/apache/axis2/transport/http/CommonsHTTPTransportSender.java
+++ b/modules/transport/http/src/org/apache/axis2/transport/http/CommonsHTTPTransportSender.java
@@ -78,6 +78,8 @@ public class CommonsHTTPTransportSender extends AbstractHandler implements
 
     private int connectionTimeout = HTTPConstants.DEFAULT_CONNECTION_TIMEOUT;
 
+    private int connectionIdleTimeout = HTTPConstants.DEFAULT_CONNECTION_IDLE_TIMEOUT;
+
     public void cleanup(MessageContext msgContext) throws AxisFault {
         HttpMethod httpMethod = (HttpMethod) msgContext.getProperty(HTTPConstants.HTTP_METHOD);
 
@@ -127,6 +129,8 @@ public class CommonsHTTPTransportSender extends AbstractHandler implements
                     .getParameter(HTTPConstants.SO_TIMEOUT);
             Parameter tempConnTimeoutParam = transportOut
                     .getParameter(HTTPConstants.CONNECTION_TIMEOUT);
+            Parameter tempConnIdleTimeout = transportOut
+                    .getParameter(HTTPConstants.CONNECTION_IDLE_TIMEOUT);
 
             if (tempSoTimeoutParam != null) {
                 soTimeout = Integer.parseInt((String) tempSoTimeoutParam
@@ -136,6 +140,11 @@ public class CommonsHTTPTransportSender extends AbstractHandler implements
             if (tempConnTimeoutParam != null) {
                 connectionTimeout = Integer
                         .parseInt((String) tempConnTimeoutParam.getValue());
+            }
+
+            if (tempConnIdleTimeout != null) {
+                connectionIdleTimeout = Integer
+                        .parseInt((String) tempConnIdleTimeout.getValue());
             }
         } catch (NumberFormatException nfe) {
 
@@ -156,6 +165,7 @@ public class CommonsHTTPTransportSender extends AbstractHandler implements
             
             connectionManager.getParams().setSoTimeout(soTimeout);
             connectionManager.getParams().setConnectionTimeout(connectionTimeout);
+            connectionManager.getParams().setConnectionIdleTimeout(connectionIdleTimeout);
 
             if (defaultMaxConnectionsPerHostParam != null &&
                     defaultMaxConnectionsPerHostParam.getValue() != null) {


### PR DESCRIPTION
This pull request adds support for configuring an HTTP connection idle timeout in the Axis2 Commons HTTP transport layer. The main changes introduce a new `CONNECTION_IDLE_TIMEOUT` parameter, allow it to be set via configuration, and ensure it is properly applied to the underlying HTTP connection manager. Additionally, the dependency on `commons-httpclient` is updated to a WSO2 Orbit version.

**HTTP Connection Idle Timeout Support:**

* Added a new constant `CONNECTION_IDLE_TIMEOUT` and its default value `DEFAULT_CONNECTION_IDLE_TIMEOUT` to `HTTPConstants`, enabling configuration of idle timeout for HTTP connections. 
* Updated `CommonsHTTPTransportSender` to support reading the `CONNECTION_IDLE_TIMEOUT` parameter from configuration and storing it in a new field. 
* Set the connection idle timeout on the HTTP connection manager using the configured value.

**Dependency Management:**

* Excluded the old `commons-httpclient` dependency and added the `org.wso2.orbit.commons-httpclient:commons-httpclient:3.1.0-wso2v6.17` dependency to ensure the correct version is used.

fix - https://github.com/wso2/product-integrator-mi/issues/4933